### PR TITLE
feat(admin/user): add role-based permissions, user management console, and temporarily disable chat UI

### DIFF
--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -28,6 +28,15 @@ import { siteConfig } from "@/config/site";
 
 export default function ChatPage() {
   const router = useRouter();
+  useEffect(() => {
+    router.replace("/");
+  }, [router]);
+
+  return null;
+}
+
+function ChatPageDisabled() {
+  const router = useRouter();
   const confirm = useConfirm();
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;

--- a/app/(main)/admin/users/page.tsx
+++ b/app/(main)/admin/users/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { authClient } from "@/lib/auth-client";
+import { UserManagementTable } from "@/components/admin/user-management-table";
+import { ShieldAlert, ShieldCheck, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function AdminUsersPage() {
+  const session = authClient.useSession();
+  const isLoggedIn = !!session.data?.user;
+
+  const currentUserProfile = useQuery(
+    api.users.getCurrentUser,
+    isLoggedIn ? {} : "skip",
+  );
+
+  if (!isLoggedIn || currentUserProfile === undefined) {
+    return (
+      <div className="flex h-[70vh] flex-col items-center justify-center gap-3">
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+        <span className="text-sm font-semibold text-zinc-400">
+          Checking permissions...
+        </span>
+      </div>
+    );
+  }
+
+  const role = currentUserProfile?.role || "user";
+  const isAuthorized = role === "owner" || role === "admin";
+
+  if (!isAuthorized) {
+    return (
+      <div className="mx-auto max-w-xl px-4 py-24 text-center">
+        <div className="mb-4 inline-flex rounded-2xl border border-rose-500/20 bg-rose-500/10 p-4 text-rose-400">
+          <ShieldAlert className="h-10 w-10" />
+        </div>
+        <h1 className="mb-2 text-2xl font-black tracking-tight text-white">
+          Access Denied
+        </h1>
+        <p className="mb-6 text-sm text-zinc-400">
+          You do not have permission to view the User Management console. Only
+          platform Owners and Admins can access this area.
+        </p>
+        <Link href="/">
+          <Button variant="default" className="rounded-xl font-bold">
+            Back to Home
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-8 pt-24">
+      {/* Top Banner */}
+      <div className="flex flex-col gap-2 border-b border-zinc-800/80 pb-6">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-6 w-6 text-amber-400" />
+          <h1 className="text-2xl font-extrabold tracking-tight text-white">
+            User Management Console
+          </h1>
+        </div>
+        <p className="text-xs text-zinc-400">
+          Manage member roles, review status, suspend or ban problematic
+          accounts.
+        </p>
+      </div>
+
+      {/* Main Table Component */}
+      <UserManagementTable currentUserRole={role} />
+    </div>
+  );
+}

--- a/components/activity-card.tsx
+++ b/components/activity-card.tsx
@@ -20,11 +20,13 @@ import { cn } from "@/lib/utils";
 import moment from "moment";
 import Link from "next/link";
 import { toast } from "sonner";
+import { UserRoleBadge } from "@/components/user-role-badge";
 
 interface ActivityUser {
   name: string;
   username: string;
   image?: string;
+  role?: string;
 }
 
 interface Activity {
@@ -60,6 +62,7 @@ interface EnrichedComment {
     name: string;
     username: string;
     image?: string;
+    role?: string;
   };
 }
 
@@ -143,12 +146,15 @@ export default function ActivityCard({
   // Helper to generate the text based on activity type
   const renderActivityText = () => {
     const displayName = (
-      <Link
-        href={`/@${activity.user.username}`}
-        className="hover:text-primary font-bold text-white transition-colors"
-      >
-        {activity.user.name}
-      </Link>
+      <span className="inline-flex items-center gap-1.5 flex-wrap">
+        <Link
+          href={`/@${activity.user.username}`}
+          className="hover:text-primary font-bold text-white transition-colors"
+        >
+          {activity.user.name}
+        </Link>
+        <UserRoleBadge role={activity.user.role} />
+      </span>
     );
 
     const mediaLink = (
@@ -376,9 +382,12 @@ export default function ActivityCard({
                         </Avatar>
                         <div className="min-w-0 flex-1 text-left">
                           <div className="flex items-center justify-between">
-                            <span className="text-[10px] font-extrabold text-white">
-                              {comment.user?.name}
-                            </span>
+                            <div className="flex items-center gap-1">
+                              <span className="text-[10px] font-extrabold text-white">
+                                {comment.user?.name}
+                              </span>
+                              <UserRoleBadge role={comment.user?.role} />
+                            </div>
                             <span className="text-[9px] font-semibold text-zinc-500">
                               {moment(comment.createdAt).fromNow()}
                             </span>

--- a/components/activity-feed.tsx
+++ b/components/activity-feed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { usePaginatedQuery } from "convex/react";
+import { usePaginatedQuery, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { authClient } from "@/lib/auth-client";
 import ActivityCard from "./activity-card";
@@ -31,9 +31,14 @@ export default function ActivityFeed() {
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
 
-  const [scope, setScope] = useState<"global" | "friends">(
-    isLoggedIn ? "friends" : "global",
+  const currentUserProfile = useQuery(
+    api.users.getCurrentUser,
+    isLoggedIn ? {} : "skip"
   );
+  const isOwnerOrAdmin =
+    currentUserProfile?.role === "owner" || currentUserProfile?.role === "admin";
+
+  const [scope, setScope] = useState<"global" | "friends">("friends");
   const [activeFilter, setActiveFilter] = useState("all");
 
   const { results, status, loadMore } = usePaginatedQuery(
@@ -46,9 +51,8 @@ export default function ActivityFeed() {
   );
 
   const handleScopeChange = (newScope: "global" | "friends") => {
-    if (newScope === "friends" && !isLoggedIn) {
-      return; // disable switching to friends feed if not logged in
-    }
+    if (newScope === "friends" && !isLoggedIn) return;
+    if (newScope === "global" && !isOwnerOrAdmin) return;
     setScope(newScope);
   };
 
@@ -61,41 +65,39 @@ export default function ActivityFeed() {
             Activity Feed
           </h1>
           <p className="mt-1 text-xs text-zinc-400">
-            See updates from friends and the popcorn community.
+            See updates from your friends.
           </p>
         </div>
 
-        {/* Global vs Friends scope toggle */}
-        <div className="border-zinc-850/60 flex self-start rounded-xl border bg-zinc-950/60 p-1 shadow-inner sm:self-auto">
-          <button
-            onClick={() => handleScopeChange("friends")}
-            disabled={!isLoggedIn}
-            className={cn(
-              "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-bold transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-40",
-              scope === "friends"
-                ? "bg-primary text-white shadow-md"
-                : "text-zinc-400 hover:text-zinc-200",
-            )}
-            title={
-              !isLoggedIn ? "Log in to see friends activity" : "Friends Feed"
-            }
-          >
-            <Users className="h-3.5 w-3.5" />
-            Friends
-          </button>
-          <button
-            onClick={() => handleScopeChange("global")}
-            className={cn(
-              "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-bold transition-all duration-300",
-              scope === "global"
-                ? "bg-primary text-white shadow-md"
-                : "text-zinc-400 hover:text-zinc-200",
-            )}
-          >
-            <Globe className="h-3.5 w-3.5" />
-            Global
-          </button>
-        </div>
+        {/* Global vs Friends scope toggle - Global only visible for Owner/Admin */}
+        {isOwnerOrAdmin && (
+          <div className="border-zinc-850/60 flex self-start rounded-xl border bg-zinc-950/60 p-1 shadow-inner sm:self-auto">
+            <button
+              onClick={() => handleScopeChange("friends")}
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-bold transition-all duration-300",
+                scope === "friends"
+                  ? "bg-primary text-white shadow-md"
+                  : "text-zinc-400 hover:text-zinc-200",
+              )}
+            >
+              <Users className="h-3.5 w-3.5" />
+              Friends
+            </button>
+            <button
+              onClick={() => handleScopeChange("global")}
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-bold transition-all duration-300",
+                scope === "global"
+                  ? "bg-primary text-white shadow-md"
+                  : "text-zinc-400 hover:text-zinc-200",
+              )}
+            >
+              <Globe className="h-3.5 w-3.5" />
+              Global
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Filter Row */}

--- a/components/admin/user-management-table.tsx
+++ b/components/admin/user-management-table.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { UserRoleBadge } from "@/components/user-role-badge";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { toast } from "sonner";
+import {
+  Search,
+  Shield,
+  ShieldCheck,
+  UserCheck,
+  UserX,
+  Ban,
+  MoreVertical,
+  Loader2,
+  Users,
+} from "lucide-react";
+import Link from "next/link";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface ManagedUser {
+  _id: Id<"users">;
+  userId: string;
+  name: string;
+  username: string;
+  email: string;
+  image?: string;
+  role: string;
+  status: string;
+  country?: string;
+  bio?: string;
+}
+
+interface UserManagementTableProps {
+  currentUserRole: string;
+}
+
+export function UserManagementTable({
+  currentUserRole,
+}: UserManagementTableProps) {
+  const confirm = useConfirm();
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const [loadingUserAction, setLoadingUserAction] = useState<string | null>(
+    null,
+  );
+
+  const users = useQuery(api.users.getAdminUsersList, {
+    search: search.trim() || undefined,
+    roleFilter: roleFilter !== "all" ? roleFilter : undefined,
+    statusFilter: statusFilter !== "all" ? statusFilter : undefined,
+  }) as ManagedUser[] | undefined;
+
+  const updateUserRoleMutation = useMutation(api.users.updateUserRole);
+  const updateUserStatusMutation = useMutation(api.users.updateUserStatus);
+
+  const handleRoleChange = async (user: ManagedUser, newRole: string) => {
+    setActiveDropdown(null);
+    if (user.role === newRole) return;
+
+    if (currentUserRole !== "owner") {
+      toast.error("Only the Owner can manage user roles");
+      return;
+    }
+
+    if (
+      await confirm({
+        title: `Change User Role`,
+        description: `Are you sure you want to change @${user.username}'s role from ${user.role.toUpperCase()} to ${newRole.toUpperCase()}?`,
+        confirmText: "Change Role",
+      })
+    ) {
+      setLoadingUserAction(user._id);
+      try {
+        await updateUserRoleMutation({
+          targetUserId: user._id,
+          newRole,
+        });
+        toast.success(`Role for @${user.username} changed to ${newRole}`);
+      } catch (err: unknown) {
+        const errorObj = err as { message?: string };
+        toast.error(errorObj.message || "Failed to update role");
+      } finally {
+        setLoadingUserAction(null);
+      }
+    }
+  };
+
+  const handleStatusChange = async (user: ManagedUser, newStatus: string) => {
+    setActiveDropdown(null);
+    if (user.status === newStatus) return;
+
+    const actionTitle =
+      newStatus === "suspended"
+        ? "Suspend User"
+        : newStatus === "banned"
+          ? "Ban User"
+          : "Reactivate User";
+
+    if (
+      await confirm({
+        title: actionTitle,
+        description: `Are you sure you want to set @${user.username}'s status to ${newStatus.toUpperCase()}?`,
+        confirmText: actionTitle,
+      })
+    ) {
+      setLoadingUserAction(user._id);
+      try {
+        await updateUserStatusMutation({
+          targetUserId: user._id,
+          newStatus,
+        });
+        toast.success(`User @${user.username} status updated to ${newStatus}`);
+      } catch (err: unknown) {
+        const errorObj = err as { message?: string };
+        toast.error(errorObj.message || "Failed to update status");
+      } finally {
+        setLoadingUserAction(null);
+      }
+    }
+  };
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "active":
+        return (
+          <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-bold text-emerald-400">
+            <UserCheck className="h-3 w-3" />
+            Active
+          </span>
+        );
+      case "suspended":
+        return (
+          <span className="inline-flex items-center gap-1 rounded-md border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-400">
+            <UserX className="h-3 w-3" />
+            Suspended
+          </span>
+        );
+      case "banned":
+        return (
+          <span className="inline-flex items-center gap-1 rounded-md border border-rose-500/20 bg-rose-500/10 px-2 py-0.5 text-[11px] font-bold text-rose-400">
+            <Ban className="h-3 w-3" />
+            Banned
+          </span>
+        );
+      default:
+        return (
+          <span className="inline-flex items-center gap-1 rounded-md bg-zinc-800 px-2 py-0.5 text-[11px] font-bold text-zinc-400">
+            {status}
+          </span>
+        );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header & Controls */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative max-w-md flex-1">
+          <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-zinc-500" />
+          <Input
+            placeholder="Search by name, username, or email..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="focus:border-primary rounded-xl border-zinc-800 bg-zinc-900/60 pl-9 text-sm"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Role Filter */}
+          <Select
+            value={roleFilter}
+            onValueChange={(val) => setRoleFilter(val ?? "all")}
+          >
+            <SelectTrigger className="h-9 w-36 rounded-xl border-zinc-800 bg-zinc-900/60 text-xs text-zinc-300 focus:border-zinc-700">
+              <SelectValue>
+                {roleFilter === "all"
+                  ? "All Roles"
+                  : roleFilter === "owner"
+                    ? "Owner"
+                    : roleFilter === "admin"
+                      ? "Admin"
+                      : "User"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="rounded-2xl border-zinc-800 bg-zinc-950 text-zinc-300">
+              <SelectGroup>
+                <SelectItem value="all">All Roles</SelectItem>
+                <SelectItem value="owner">Owner</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="user">User</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+
+          {/* Status Filter */}
+          <Select
+            value={statusFilter}
+            onValueChange={(val) => setStatusFilter(val ?? "all")}
+          >
+            <SelectTrigger className="h-9 w-36 rounded-xl border-zinc-800 bg-zinc-900/60 text-xs text-zinc-300 focus:border-zinc-700">
+              <SelectValue>
+                {statusFilter === "all"
+                  ? "All Statuses"
+                  : statusFilter === "active"
+                    ? "Active"
+                    : statusFilter === "suspended"
+                      ? "Suspended"
+                      : "Banned"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="rounded-2xl border-zinc-800 bg-zinc-950 text-zinc-300">
+              <SelectGroup>
+                <SelectItem value="all">All Statuses</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="suspended">Suspended</SelectItem>
+                <SelectItem value="banned">Banned</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Users Table */}
+      <div className="overflow-hidden rounded-2xl border border-zinc-800/80 bg-zinc-900/40 shadow-xl backdrop-blur-md">
+        {users === undefined ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-16 text-zinc-500">
+            <Loader2 className="text-primary h-6 w-6 animate-spin" />
+            <span className="text-xs font-semibold">
+              Loading users database...
+            </span>
+          </div>
+        ) : users.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-16 text-zinc-500">
+            <Users className="h-8 w-8 text-zinc-600" />
+            <span className="text-sm font-semibold text-zinc-400">
+              No users found
+            </span>
+            <span className="text-xs text-zinc-600">
+              Try adjusting your search query or filters.
+            </span>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs text-zinc-300">
+              <thead className="border-b border-zinc-800 bg-zinc-900/80 text-[11px] font-bold tracking-wider text-zinc-400 uppercase">
+                <tr>
+                  <th className="px-5 py-3.5">User</th>
+                  <th className="px-5 py-3.5">Email</th>
+                  <th className="px-5 py-3.5">Role</th>
+                  <th className="px-5 py-3.5">Status</th>
+                  <th className="px-5 py-3.5 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800/50">
+                {users.map((user) => {
+                  const fallbackInitial = user.name
+                    ? user.name.charAt(0).toUpperCase()
+                    : "?";
+                  const isLoadingThis = loadingUserAction === user._id;
+
+                  return (
+                    <tr
+                      key={user._id}
+                      className="transition-colors hover:bg-zinc-800/20"
+                    >
+                      {/* User Column */}
+                      <td className="px-5 py-3.5 whitespace-nowrap">
+                        <div className="flex items-center gap-3">
+                          <Link href={`/@${user.username}`}>
+                            <Avatar className="hover:ring-primary/50 h-9 w-9 border border-zinc-800 transition-all hover:ring-2">
+                              <AvatarImage src={user.image} alt={user.name} />
+                              <AvatarFallback className="bg-zinc-800 text-xs font-bold text-zinc-300">
+                                {fallbackInitial}
+                              </AvatarFallback>
+                            </Avatar>
+                          </Link>
+                          <div>
+                            <div className="flex items-center gap-1.5 font-bold text-white">
+                              <Link
+                                href={`/@${user.username}`}
+                                className="hover:underline"
+                              >
+                                {user.name}
+                              </Link>
+                              <UserRoleBadge role={user.role} />
+                            </div>
+                            <span className="text-[11px] font-semibold text-zinc-500">
+                              @{user.username}
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+
+                      {/* Email */}
+                      <td className="px-5 py-3.5 font-medium whitespace-nowrap text-zinc-400">
+                        {user.email}
+                      </td>
+
+                      {/* Role */}
+                      <td className="px-5 py-3.5 whitespace-nowrap">
+                        <span className="font-bold text-zinc-300 capitalize">
+                          {user.role}
+                        </span>
+                      </td>
+
+                      {/* Status */}
+                      <td className="px-5 py-3.5 whitespace-nowrap">
+                        {getStatusBadge(user.status)}
+                      </td>
+
+                      {/* Actions */}
+                      <td className="px-5 py-3.5 text-right whitespace-nowrap">
+                        {isLoadingThis ? (
+                          <Loader2 className="inline-block h-4 w-4 animate-spin text-zinc-400" />
+                        ) : (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border-0 p-0 text-zinc-400 outline-none hover:bg-zinc-800 hover:text-white">
+                              <MoreVertical className="h-4 w-4 text-zinc-400" />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              align="end"
+                              className="w-48 rounded-2xl border border-zinc-800 bg-zinc-950 p-1.5 shadow-2xl"
+                            >
+                              {/* Quick Navigation Link for All Users */}
+                              <DropdownMenuGroup>
+                                <DropdownMenuItem className="rounded-xl p-0">
+                                  <Link
+                                    href={`/@${user.username}`}
+                                    className="flex w-full cursor-pointer items-center px-3 py-2 text-xs font-semibold text-zinc-300 hover:text-white focus:bg-zinc-800 focus:text-white"
+                                  >
+                                    <Users className="mr-2 h-3.5 w-3.5 text-zinc-400" />
+                                    View Profile
+                                  </Link>
+                                </DropdownMenuItem>
+                              </DropdownMenuGroup>
+
+                              {/* Role Management */}
+                              {currentUserRole === "owner" &&
+                                user.role !== "owner" && (
+                                  <>
+                                    <DropdownMenuSeparator className="my-1 bg-zinc-800" />
+                                    <DropdownMenuGroup>
+                                      <DropdownMenuLabel className="px-2 py-1 text-[10px] font-bold text-zinc-500 uppercase">
+                                        Change Role
+                                      </DropdownMenuLabel>
+                                      {user.role !== "admin" && (
+                                        <DropdownMenuItem
+                                          onClick={() =>
+                                            handleRoleChange(user, "admin")
+                                          }
+                                          className="cursor-pointer rounded-xl text-xs font-semibold text-blue-400 focus:bg-blue-500/10 focus:text-blue-300"
+                                        >
+                                          <ShieldCheck className="mr-2 h-3.5 w-3.5 text-blue-400" />
+                                          Make Admin
+                                        </DropdownMenuItem>
+                                      )}
+                                      {user.role !== "user" && (
+                                        <DropdownMenuItem
+                                          onClick={() =>
+                                            handleRoleChange(user, "user")
+                                          }
+                                          className="cursor-pointer rounded-xl text-xs font-semibold text-zinc-300 focus:bg-zinc-800 focus:text-white"
+                                        >
+                                          <Shield className="mr-2 h-3.5 w-3.5 text-zinc-400" />
+                                          Demote to User
+                                        </DropdownMenuItem>
+                                      )}
+                                    </DropdownMenuGroup>
+                                  </>
+                                )}
+
+                              {/* Account Status Management */}
+                              {user.role !== "owner" ? (
+                                <>
+                                  <DropdownMenuSeparator className="my-1 bg-zinc-800" />
+                                  <DropdownMenuGroup>
+                                    <DropdownMenuLabel className="px-2 py-1 text-[10px] font-bold text-zinc-500 uppercase">
+                                      Account Status
+                                    </DropdownMenuLabel>
+                                    {user.status !== "active" && (
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          handleStatusChange(user, "active")
+                                        }
+                                        className="cursor-pointer rounded-xl text-xs font-semibold text-emerald-400 focus:bg-emerald-500/10 focus:text-emerald-300"
+                                      >
+                                        <UserCheck className="mr-2 h-3.5 w-3.5 text-emerald-400" />
+                                        Activate User
+                                      </DropdownMenuItem>
+                                    )}
+                                    {user.status !== "suspended" && (
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          handleStatusChange(user, "suspended")
+                                        }
+                                        className="cursor-pointer rounded-xl text-xs font-semibold text-amber-400 focus:bg-amber-500/10 focus:text-amber-300"
+                                      >
+                                        <UserX className="mr-2 h-3.5 w-3.5 text-amber-400" />
+                                        Suspend User
+                                      </DropdownMenuItem>
+                                    )}
+                                    {user.status !== "banned" && (
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          handleStatusChange(user, "banned")
+                                        }
+                                        className="cursor-pointer rounded-xl text-xs font-semibold text-rose-400 focus:bg-rose-500/10 focus:text-rose-300"
+                                      >
+                                        <Ban className="mr-2 h-3.5 w-3.5 text-rose-400" />
+                                        Ban Account
+                                      </DropdownMenuItem>
+                                    )}
+                                  </DropdownMenuGroup>
+                                </>
+                              ) : (
+                                <>
+                                  <DropdownMenuSeparator className="my-1 bg-zinc-800" />
+                                  <DropdownMenuGroup>
+                                    <DropdownMenuLabel className="px-2 py-1 text-[10px] font-medium text-zinc-500 italic">
+                                      Owner accounts are protected & cannot be
+                                      suspended.
+                                    </DropdownMenuLabel>
+                                  </DropdownMenuGroup>
+                                </>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/comments-section.tsx
+++ b/components/comments-section.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
 import { useConfirm } from "@/components/ui/confirm-provider";
+import { UserRoleBadge } from "@/components/user-role-badge";
 
 // Props for CommentsSection
 interface CommentsSectionProps {
@@ -47,6 +48,7 @@ interface CommentType {
     name: string;
     username: string;
     image?: string;
+    role?: string;
   };
   likeCount: number;
   replyCount: number;
@@ -446,6 +448,9 @@ function CommentNode({
                 <span className="text-xs text-zinc-500">
                   @{comment.author.username}
                 </span>
+              )}
+              {!isDeletedUser && (
+                <UserRoleBadge role={comment.author.role} />
               )}
               <span className="text-xs font-semibold text-zinc-600">•</span>
               <span

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -22,6 +22,7 @@ import {
   Activity,
   Popcorn,
   List,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
@@ -54,6 +55,12 @@ export default function Navbar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isSearchPage = pathname === "/search";
+
+  // Get current user profile (including role)
+  const userProfile = useQuery(
+    api.users.getCurrentUser,
+    isLoggedIn ? {} : "skip"
+  );
 
   // Notifications query & mutations
   const notifications = useQuery(
@@ -577,6 +584,22 @@ export default function Navbar() {
                   <DropdownMenuSeparator className="my-1 bg-zinc-800" />
 
                   {/* Chats link hidden */}
+                  {(userProfile?.role === "owner" || userProfile?.role === "admin") && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setDropdownMenuOpen(false);
+                          router.push("/admin/users");
+                        }}
+                        className="cursor-pointer rounded-xl px-3 py-2 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300 focus:bg-amber-500/10 focus:text-amber-300"
+                      >
+                        <ShieldCheck className="mr-2 h-4 w-4 text-amber-400" />
+                        Admin Panel
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator className="my-1 bg-zinc-800" />
+                    </>
+                  )}
+
                   <DropdownMenuItem
                     onClick={() => {
                       setDropdownMenuOpen(false);

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -576,16 +576,7 @@ export default function Navbar() {
 
                   <DropdownMenuSeparator className="my-1 bg-zinc-800" />
 
-                  <DropdownMenuItem
-                    onClick={() => {
-                      setDropdownMenuOpen(false);
-                      router.push("/chat");
-                    }}
-                    className="cursor-pointer rounded-xl px-3 py-2 text-zinc-300 hover:bg-zinc-800 hover:text-white focus:bg-zinc-800 focus:text-white"
-                  >
-                    <MessageSquare className="mr-2 h-4 w-4 text-zinc-400" />
-                    Chats
-                  </DropdownMenuItem>
+                  {/* Chats link hidden */}
                   <DropdownMenuItem
                     onClick={() => {
                       setDropdownMenuOpen(false);
@@ -1008,15 +999,6 @@ export default function Navbar() {
                   </Link>
                   {isLoggedIn && (
                     <>
-                      <Link
-                        href="/chat"
-                        prefetch={false}
-                        onClick={() => setMobileMenuOpen(false)}
-                        className="flex items-center gap-2 hover:text-white"
-                      >
-                        <MessageSquare className="h-4 w-4" />
-                        Chats
-                      </Link>
                       <Link
                         href="/lists"
                         prefetch={false}

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Users, Loader2, UserPlus, UserCheck, UserX } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { UserRoleBadge } from "@/components/user-role-badge";
 import { UserDoc } from "./types";
 
 interface ProfileHeaderProps {
@@ -74,6 +75,17 @@ export function ProfileHeader({
               <span className="text-primary text-sm font-semibold">
                 @{targetUser?.username}
               </span>
+              <UserRoleBadge role={targetUser?.role} />
+              {targetUser?.status === "suspended" && (
+                <span className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-extrabold tracking-wide text-amber-400">
+                  Suspended
+                </span>
+              )}
+              {targetUser?.status === "banned" && (
+                <span className="rounded-md border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-[10px] font-extrabold tracking-wide text-rose-400">
+                  Banned
+                </span>
+              )}
               {targetUser?.country && (
                 <span className="rounded-full border border-zinc-800 bg-zinc-900 px-2.5 py-0.5 text-[10px] font-bold tracking-wider text-zinc-400 uppercase">
                   {targetUser?.country}

--- a/components/profile/types.ts
+++ b/components/profile/types.ts
@@ -15,6 +15,8 @@ export interface UserDoc {
   hideRatings?: boolean;
   hideDiary?: boolean;
   hideInsights?: boolean;
+  role?: string;
+  status?: string;
 }
 
 export interface DiaryItem {

--- a/components/user-role-badge.tsx
+++ b/components/user-role-badge.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import { Crown, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface UserRoleBadgeProps {
+  role?: string;
+  className?: string;
+  showIcon?: boolean;
+}
+
+export function UserRoleBadge({
+  role,
+  className,
+  showIcon = true,
+}: UserRoleBadgeProps) {
+  if (!role || role === "user") return null;
+
+  const normalizedRole = role.toLowerCase();
+
+  if (normalizedRole === "owner") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide rounded-md",
+          "bg-gradient-to-r from-amber-500/20 via-yellow-500/20 to-amber-500/20",
+          "text-amber-400 border border-amber-500/30 shadow-[0_0_8px_rgba(245,158,11,0.2)]",
+          "select-none",
+          className
+        )}
+        title="Project Owner"
+      >
+        {showIcon && <Crown className="w-3 h-3 text-amber-400 fill-amber-400/20 shrink-0" />}
+        <span>Owner</span>
+      </span>
+    );
+  }
+
+  if (normalizedRole === "admin") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide rounded-md",
+          "bg-blue-500/15 text-blue-400 border border-blue-500/30",
+          "select-none",
+          className
+        )}
+        title="Administrator"
+      >
+        {showIcon && <ShieldCheck className="w-3 h-3 text-blue-400 shrink-0" />}
+        <span>Admin</span>
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -176,6 +176,7 @@ export const getFeed = query({
           name: activityUser.name,
           username: activityUser.username,
           image: activityUser.image,
+          role: activityUser.role,
         },
         likesCount: likes.length,
         commentsCount: comments.length,
@@ -228,6 +229,7 @@ export const getActivityDetails = query({
             name: commentUser.name,
             username: commentUser.username,
             image: commentUser.image,
+            role: commentUser.role,
           },
         });
       }
@@ -246,6 +248,7 @@ export const getActivityDetails = query({
         name: activityUser.name,
         username: activityUser.username,
         image: activityUser.image,
+        role: activityUser.role,
       } : null,
       likes,
       comments: enrichedComments,

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -1,6 +1,7 @@
 import { mutation, query, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
+import { ensureActiveUser } from "./users";
 
 // ----------------------------------------------------
 // INTERNAL HELPERS
@@ -34,6 +35,15 @@ export async function logActivity(
     season?: number;
   }
 ) {
+  // Validate that user is active (not suspended/banned)
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+    .first();
+
+  if (user && (user.status === "banned" || user.status === "suspended")) {
+    throw new Error(`Your account is ${user.status} and cannot log activities.`);
+  }
   // To keep the feed clean, remove existing activities of the same type for this user + media
   // (e.g. if they re-add to watchlist or re-rate, we delete the old activity so the new one floats to top)
   if (args.type === "watchlist" || args.type === "favorite" || args.type === "rate" || args.type === "completed_season") {
@@ -123,7 +133,12 @@ export const getFeed = query({
 
     let allowedUserIds: string[] | null = null;
 
-    if (scope === "friends") {
+    if (scope === "global") {
+      // Only Owner and Admin can access global scope feed
+      if (!user || (user.role !== "owner" && user.role !== "admin")) {
+        return { page: [], isDone: true, continueCursor: "" };
+      }
+    } else if (scope === "friends") {
       if (!user) return { page: [], isDone: true, continueCursor: "" };
       const friends = await getFriendsIds(ctx, user.userId);
       allowedUserIds = [user.userId, ...friends];
@@ -264,8 +279,7 @@ export const getActivityDetails = query({
 export const likeActivity = mutation({
   args: { activityId: v.id("activities") },
   handler: async (ctx, args) => {
-    const user = await getAuthedUser(ctx);
-    if (!user) throw new Error("Must be logged in to like activities");
+    const user = await ensureActiveUser(ctx);
 
     const existingLike = await ctx.db
       .query("activityLikes")
@@ -294,8 +308,7 @@ export const addComment = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    const user = await getAuthedUser(ctx);
-    if (!user) throw new Error("Must be logged in to comment on activities");
+    const user = await ensureActiveUser(ctx);
 
     const content = args.content.trim();
     if (!content) throw new Error("Comment content cannot be empty");
@@ -314,8 +327,7 @@ export const addComment = mutation({
 export const deleteComment = mutation({
   args: { commentId: v.id("activityComments") },
   handler: async (ctx, args) => {
-    const user = await getAuthedUser(ctx);
-    if (!user) throw new Error("Must be logged in to delete comments");
+    const user = await ensureActiveUser(ctx);
 
     const comment = await ctx.db.get(args.commentId);
     if (!comment) throw new Error("Comment not found");

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -2,6 +2,7 @@ import { mutation, query, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
 import { Id } from "./_generated/dataModel";
+import { ensureActiveUser } from "./users";
 
 // Helper to get current authenticated user profile
 async function getAuthedUserProfile(ctx: QueryCtx | MutationCtx) {
@@ -164,10 +165,7 @@ export const addComment = mutation({
     parentId: v.optional(v.id("comments")),
   },
   handler: async (ctx, args) => {
-    const currentUser = await getAuthedUserProfile(ctx);
-    if (!currentUser) {
-      throw new Error("Must be logged in to post a comment");
-    }
+    const currentUser = await ensureActiveUser(ctx);
 
     const trimmedContent = args.content.trim();
     if (trimmedContent.length === 0) {
@@ -241,10 +239,7 @@ export const editComment = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    const currentUser = await getAuthedUserProfile(ctx);
-    if (!currentUser) {
-      throw new Error("Must be logged in to edit a comment");
-    }
+    const currentUser = await ensureActiveUser(ctx);
 
     const comment = await ctx.db.get(args.commentId);
     if (!comment) {
@@ -306,10 +301,7 @@ export const deleteComment = mutation({
     commentId: v.id("comments"),
   },
   handler: async (ctx, args) => {
-    const currentUser = await getAuthedUserProfile(ctx);
-    if (!currentUser) {
-      throw new Error("Must be logged in to delete a comment");
-    }
+    const currentUser = await ensureActiveUser(ctx);
 
     const comment = await ctx.db.get(args.commentId);
     if (!comment) {
@@ -329,10 +321,7 @@ export const toggleLikeComment = mutation({
     commentId: v.id("comments"),
   },
   handler: async (ctx, args) => {
-    const currentUser = await getAuthedUserProfile(ctx);
-    if (!currentUser) {
-      throw new Error("Must be logged in to like a comment");
-    }
+    const currentUser = await ensureActiveUser(ctx);
 
     const comment = await ctx.db.get(args.commentId);
     if (!comment) {

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -30,6 +30,7 @@ interface EnrichedComment {
     name: string;
     username: string;
     image?: string;
+    role?: string;
   };
   likeCount: number;
   replyCount: number;
@@ -86,10 +87,12 @@ export const getComments = query({
           name: author.name,
           username: author.username,
           image: author.image,
+          role: author.role,
         } : {
           name: "[deleted]",
           username: "[deleted]",
           image: undefined,
+          role: undefined,
         },
         likeCount,
         replyCount,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,6 +22,7 @@ export default defineSchema({
     status: v.optional(v.string()), // "active" | "deleted" | "closed"
     messagePrivacy: v.optional(v.string()), // "friends" | "disabled"
     readReceiptsEnabled: v.optional(v.boolean()), // true = visible, false = hidden
+    role: v.optional(v.string()), // "owner" | "admin" | "user"
   })
     .index("by_username", ["username"])
     .index("by_userId", ["userId"]),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -70,6 +70,7 @@ export const createOrUpdateProfile = mutation({
         name: args.name,
         email: args.email,
         status: "active",
+        role: "user",
       });
     }
   },
@@ -164,6 +165,7 @@ export const updateCurrentUserProfile = mutation({
         bio: args.bio,
         country: args.country,
         status: "active",
+        role: "user",
       });
     }
   },
@@ -402,5 +404,30 @@ export const updateUserThemeSettings = mutation({
     return profile._id;
   },
 });
+
+// Migration helper to backfill missing/undefined roles to "user"
+export const migrateUserRoles = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const allUsers = await ctx.db.query("users").collect();
+    let updatedCount = 0;
+
+    for (const user of allUsers) {
+      if (!user.role) {
+        await ctx.db.patch(user._id, {
+          role: "user",
+        });
+        updatedCount++;
+      }
+    }
+
+    return {
+      message: `Migration completed successfully`,
+      updatedUsersCount: updatedCount,
+      totalUsersCount: allUsers.length,
+    };
+  },
+});
+
 
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,40 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
+
+export async function getAuthedUser(ctx: QueryCtx | MutationCtx) {
+  try {
+    const user = await authComponent.getAuthUser(ctx);
+    if (!user) return null;
+    return await ctx.db
+      .query("users")
+      .withIndex("by_userId", (q) => q.eq("userId", user._id))
+      .first();
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureActiveUser(ctx: QueryCtx | MutationCtx) {
+  const user = await getAuthedUser(ctx);
+  if (!user) {
+    throw new Error("Unauthorized: Please sign in");
+  }
+
+  if (user.status === "banned") {
+    throw new Error("Your account has been banned due to violations of our community guidelines.");
+  }
+
+  if (user.status === "suspended") {
+    throw new Error("Your account is currently suspended and restricted from performing interactive actions.");
+  }
+
+  if (user.status === "closed" || user.status === "deleted") {
+    throw new Error("Your account is deactivated.");
+  }
+
+  return user;
+}
 
 // Check if username is already taken (unique check)
 export const checkUsernameUnique = query({
@@ -428,6 +462,118 @@ export const migrateUserRoles = mutation({
     };
   },
 });
+
+// ----------------------------------------------------
+// ADMIN / OWNER MANAGEMENT
+// ----------------------------------------------------
+
+export const getAdminUsersList = query({
+  args: {
+    search: v.optional(v.string()),
+    roleFilter: v.optional(v.string()),
+    statusFilter: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const caller = await getAuthedUser(ctx);
+    if (!caller || (caller.role !== "owner" && caller.role !== "admin")) {
+      throw new Error("Unauthorized: Admin or Owner access required");
+    }
+
+    let users = await ctx.db.query("users").collect();
+
+    if (args.search) {
+      const q = args.search.toLowerCase().trim();
+      users = users.filter(
+        (u) =>
+          u.name.toLowerCase().includes(q) ||
+          u.username.toLowerCase().includes(q) ||
+          u.email.toLowerCase().includes(q)
+      );
+    }
+
+    if (args.roleFilter && args.roleFilter !== "all") {
+      users = users.filter((u) => (u.role || "user") === args.roleFilter);
+    }
+
+    if (args.statusFilter && args.statusFilter !== "all") {
+      users = users.filter((u) => (u.status || "active") === args.statusFilter);
+    }
+
+    return users.map((u) => ({
+      _id: u._id,
+      userId: u.userId,
+      name: u.name,
+      username: u.username,
+      email: u.email,
+      image: u.image,
+      role: u.role || "user",
+      status: u.status || "active",
+      country: u.country,
+      bio: u.bio,
+    }));
+  },
+});
+
+export const updateUserRole = mutation({
+  args: {
+    targetUserId: v.id("users"),
+    newRole: v.string(), // "user" | "admin" | "owner"
+  },
+  handler: async (ctx, args) => {
+    const caller = await getAuthedUser(ctx);
+    if (!caller || caller.role !== "owner") {
+      throw new Error("Unauthorized: Only the Owner can change user roles");
+    }
+
+    const targetUser = await ctx.db.get(args.targetUserId);
+    if (!targetUser) throw new Error("User not found");
+
+    if (targetUser.role === "owner" && targetUser._id !== caller._id) {
+      throw new Error("Cannot modify role of another Owner");
+    }
+
+    if (!["user", "admin", "owner"].includes(args.newRole)) {
+      throw new Error("Invalid role specified");
+    }
+
+    await ctx.db.patch(args.targetUserId, {
+      role: args.newRole,
+    });
+
+    return { success: true, message: `Role updated to ${args.newRole}` };
+  },
+});
+
+export const updateUserStatus = mutation({
+  args: {
+    targetUserId: v.id("users"),
+    newStatus: v.string(), // "active" | "suspended" | "banned"
+  },
+  handler: async (ctx, args) => {
+    const caller = await getAuthedUser(ctx);
+    if (!caller || (caller.role !== "owner" && caller.role !== "admin")) {
+      throw new Error("Unauthorized: Admin or Owner access required");
+    }
+
+    const targetUser = await ctx.db.get(args.targetUserId);
+    if (!targetUser) throw new Error("User not found");
+
+    if (targetUser.role === "owner" && targetUser._id !== caller._id) {
+      throw new Error("Cannot modify status of an Owner");
+    }
+
+    if (!["active", "suspended", "banned"].includes(args.newStatus)) {
+      throw new Error("Invalid status specified");
+    }
+
+    await ctx.db.patch(args.targetUserId, {
+      status: args.newStatus,
+    });
+
+    return { success: true, message: `Status updated to ${args.newStatus}` };
+  },
+});
+
 
 
 


### PR DESCRIPTION
## 📌 Summary
This PR introduces comprehensive user role management, owner/admin badges across the application, role-based backend restrictions, and temporarily disables the chat UI.

---

## 🚀 Key Changes

### 1. User Management & Role-Based Access Control (RBAC)
- Added an admin console page at `/admin/users` allowing admins/owners to search users, update roles, and manage account statuses (`Active`, `Suspended`, `Banned`).
- Implemented backend enforcement (`ensureActiveUser`) to block suspended or banned users from performing interactive mutations.
- Restricted access to the global activity feed exclusively to `Owner` and `Admin` roles.

### 2. User Role Badges & Schema Updates
- Added an optional `role` field to the Convex `users` schema (defaulting to `"user"` for new registrations).
- Created a `migrateUserRoles` Convex mutation to backfill roles for existing users.
- Introduced a reusable `<UserRoleBadge />` component to visually highlight `Owner` and `Admin` roles across comment sections, replies, activity cards, and user profile headers.

### 3. Temporary Chat UI Suppression
- Hidden the "Chats" link from the user dropdown and mobile drawer navigation.
- Configured redirect from `/chat` to home page (`/`).
- Maintained all backend logic and schemas intact for future re-activation.

---

## 🧪 Verification Plan
- [x] Verified `/admin/users` console for role updates and account status modifications.
- [x] Tested backend enforcement (`ensureActiveUser`) blocking suspended/banned users.
- [x] Checked `<UserRoleBadge />` rendering in comment items, activity feed cards, and profile headers.
- [x] Verified `/chat` route properly redirects to `/`.
