### PR TITLE
Reactivate chat feature and automate activity feed cleanup

### DIFF
--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -28,15 +28,6 @@ import { siteConfig } from "@/config/site";
 
 export default function ChatPage() {
   const router = useRouter();
-  useEffect(() => {
-    router.replace("/");
-  }, [router]);
-
-  return null;
-}
-
-function ChatPageDisabled() {
-  const router = useRouter();
   const confirm = useConfirm();
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -153,7 +153,7 @@ export default function Navbar() {
             "grid w-full grid-cols-2 transition-all duration-500 lg:grid-cols-3",
             scrolled
               ? "bg-background/80 border-border/80 mx-auto max-w-5xl rounded-full border px-6 py-2 shadow-xl shadow-black/60 backdrop-blur-md lg:pr-2 lg:pl-3"
-              : "mx-auto max-w-7xl border border-transparent px-6 py-4 sm:px-12 md:px-16",
+              : "mx-auto max-w-7xl border border-transparent px-4 py-4 sm:px-12 md:px-16",
             isSearchPage && "lg:grid-cols-2",
           )}
         >
@@ -173,8 +173,7 @@ export default function Navbar() {
             />
             <span
               className={cn(
-                "bg-linear-to-r from-white via-zinc-200 to-zinc-400 bg-clip-text font-black tracking-wider text-transparent uppercase transition-all duration-500",
-                scrolled ? "text-lg" : "text-xl",
+                "bg-linear-to-r from-white via-zinc-200 to-zinc-400 bg-clip-text text-lg font-black tracking-wider text-transparent uppercase transition-all duration-500",
               )}
             >
               POVI
@@ -583,7 +582,16 @@ export default function Navbar() {
 
                   <DropdownMenuSeparator className="my-1 bg-zinc-800" />
 
-                  {/* Chats link hidden */}
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setDropdownMenuOpen(false);
+                      router.push("/chat");
+                    }}
+                    className="cursor-pointer rounded-xl px-3 py-2 text-zinc-300 hover:bg-zinc-800 hover:text-white focus:bg-zinc-800 focus:text-white"
+                  >
+                    <MessageSquare className="mr-2 h-4 w-4 text-zinc-400" />
+                    Chats
+                  </DropdownMenuItem>
                   {(userProfile?.role === "owner" ||
                     userProfile?.role === "admin") && (
                     <>
@@ -1023,6 +1031,15 @@ export default function Navbar() {
                   </Link>
                   {isLoggedIn && (
                     <>
+                      <Link
+                        href="/chat"
+                        prefetch={false}
+                        onClick={() => setMobileMenuOpen(false)}
+                        className="flex items-center gap-2 hover:text-white"
+                      >
+                        <MessageSquare className="h-4 w-4" />
+                        Chats
+                      </Link>
                       <Link
                         href="/lists"
                         prefetch={false}

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -366,3 +366,44 @@ export const logSeasonCompletion = mutation({
     });
   },
 });
+
+// Helper to delete specific activities and their associated likes/comments
+export async function deleteActivitiesByTypeAndMedia(
+  ctx: MutationCtx,
+  userId: string,
+  type: "rate" | "watchlist" | "favorite" | "review" | "completed_season",
+  mediaId: string,
+  mediaType: string
+) {
+  const existing = await ctx.db
+    .query("activities")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  const targets = existing.filter(
+    (a) => a.type === type && a.mediaId === mediaId && a.mediaType === mediaType
+  );
+
+  for (const act of targets) {
+    await ctx.db.delete(act._id);
+
+    // Clean up likes
+    const likes = await ctx.db
+      .query("activityLikes")
+      .withIndex("by_activity", (q) => q.eq("activityId", act._id))
+      .collect();
+    for (const l of likes) {
+      await ctx.db.delete(l._id);
+    }
+
+    // Clean up comments
+    const comments = await ctx.db
+      .query("activityComments")
+      .withIndex("by_activity", (q) => q.eq("activityId", act._id))
+      .collect();
+    for (const c of comments) {
+      await ctx.db.delete(c._id);
+    }
+  }
+}
+

--- a/convex/diary.ts
+++ b/convex/diary.ts
@@ -1,7 +1,7 @@
 import { mutation, query, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
-import { logActivity } from "./activities";
+import { logActivity, deleteActivitiesByTypeAndMedia } from "./activities";
 
 // Helper to get current authenticated user profile
 async function getAuthedUser(ctx: QueryCtx | MutationCtx) {
@@ -395,6 +395,13 @@ export const deleteDiaryEntry = mutation({
     }
 
     await ctx.db.delete(args.diaryId);
+
+    // Clean up activity log
+    if (entry.review) {
+      await deleteActivitiesByTypeAndMedia(ctx, currentUser.userId, "review", entry.mediaId, entry.mediaType);
+    } else if (entry.rating !== undefined) {
+      await deleteActivitiesByTypeAndMedia(ctx, currentUser.userId, "rate", entry.mediaId, entry.mediaType);
+    }
 
     if (entry.mediaType === "tv" && entry.season !== undefined && entry.episode !== undefined) {
       await updateSeasonCompletionStatus(

--- a/convex/favorites.ts
+++ b/convex/favorites.ts
@@ -1,9 +1,10 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
-import { logActivity } from "./activities";
+import { logActivity, deleteActivitiesByTypeAndMedia } from "./activities";
 
 // Add to Favorites
+// ... (lines omitted for brevity, but let's replace the whole top section)
 export const addToFavorites = mutation({
   args: {
     mediaId: v.string(),
@@ -73,6 +74,10 @@ export const removeFromFavorites = mutation({
 
     if (existing) {
       await ctx.db.delete(existing._id);
+      
+      // Clean up favorite activity
+      await deleteActivitiesByTypeAndMedia(ctx, userId, "favorite", args.mediaId, args.mediaType);
+      
       return true;
     }
     return false;

--- a/convex/ratings.ts
+++ b/convex/ratings.ts
@@ -1,9 +1,10 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
-import { logActivity } from "./activities";
+import { logActivity, deleteActivitiesByTypeAndMedia } from "./activities";
 
 // Add or edit rating for media
+// ... (omitted code)
 export const rateMedia = mutation({
   args: {
     mediaId: v.string(),
@@ -99,6 +100,10 @@ export const deleteRating = mutation({
 
     if (existing) {
       await ctx.db.delete(existing._id);
+      
+      // Clean up rate activity
+      await deleteActivitiesByTypeAndMedia(ctx, userId, "rate", args.mediaId, args.mediaType);
+      
       return true;
     }
     return false;

--- a/convex/watchlist.ts
+++ b/convex/watchlist.ts
@@ -1,9 +1,10 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { authComponent } from "./auth";
-import { logActivity } from "./activities";
+import { logActivity, deleteActivitiesByTypeAndMedia } from "./activities";
 
 // Add to Watchlist
+// ... (lines omitted for brevity, but let's replace the whole top section)
 export const addToWatchlist = mutation({
   args: {
     mediaId: v.string(),
@@ -73,6 +74,10 @@ export const removeFromWatchlist = mutation({
 
     if (existing) {
       await ctx.db.delete(existing._id);
+      
+      // Clean up watchlist activity
+      await deleteActivitiesByTypeAndMedia(ctx, userId, "watchlist", args.mediaId, args.mediaType);
+      
       return true;
     }
     return false;


### PR DESCRIPTION
- Remove route redirection from `/chat` to `/` in `ChatPage` page component
- Restore the original `ChatPage` layout and features by renaming the disabled component back to `ChatPage`
- Re-add the "Chats" menu link in the desktop profile dropdown navigation in `Navbar`
- Re-add the "Chats" option in the mobile drawer navigation in `Navbar`
- Add `deleteActivitiesByTypeAndMedia` helper in `activities.ts`.
- Clean up watchlist activity logs in `removeFromWatchlist`.
- Clean up favorite activity logs in `removeFromFavorites`.
- Clean up rating activity logs in `deleteRating`.
- Clean up diary/review activity logs in `deleteDiaryEntry`.
- Delete related comments and likes automatically when activities are cleaned up.