### PR TITLE
feat: enhance continue watching cards, persist homepage states, and improve player navigation

### DIFF
--- a/app/(main)/user/[username]/page.tsx
+++ b/app/(main)/user/[username]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, use, useEffect } from "react";
 import { useQuery, useMutation } from "convex/react";
+import { useQueryState } from "nuqs";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { authClient } from "@/lib/auth-client";
@@ -49,15 +50,16 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   const confirm = useConfirm();
   const openAuth = useAuthModalStore((state) => state.open);
   const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
-  const [activeTab, setActiveTab] = useState<
+  const [activeTabState, setActiveTab] = useQueryState("tab", {
+    defaultValue: "all",
+  });
+  const activeTab = (activeTabState || "all") as
     | "all"
     | "watchlist"
     | "favorites"
     | "ratings"
     | "diary"
-    | "continueWatching"
-    | "insights"
-  >("all");
+    | "continue-watching";
   const [showFriendsDialog, setShowFriendsDialog] = useState(false);
   const [editingEntry, setEditingEntry] = useState<DiaryItem | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -115,7 +117,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   };
 
   const handleSelectAll = (
-    items: ({ mediaId: string; mediaType: string } | DiaryItem)[]
+    items: ({ mediaId: string; mediaType: string } | DiaryItem)[],
   ) => {
     const updated = new Set<string>();
     if (selectedItems.size < items.length) {
@@ -123,7 +125,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
         (items as DiaryItem[]).forEach((item) => updated.add(item._id));
       } else {
         (items as { mediaId: string; mediaType: string }[]).forEach((item) =>
-          updated.add(`${item.mediaType}-${item.mediaId}`)
+          updated.add(`${item.mediaType}-${item.mediaId}`),
         );
       }
     }
@@ -149,7 +151,9 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
         for (const diaryId of diaryIdsToDelete) {
           await deleteDiaryEntry({ diaryId });
         }
-        toast.success(`Successfully removed ${diaryIdsToDelete.length} diary entries!`);
+        toast.success(
+          `Successfully removed ${diaryIdsToDelete.length} diary entries!`,
+        );
       } else {
         const itemsToDelete = Array.from(selectedItems).map((key) => {
           const [mediaType, mediaId] = key.split("-");
@@ -224,35 +228,51 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   const showDiaryTab = isOwner || !targetUser?.hideDiary;
   const showInsightsTab = isOwner || !targetUser?.hideInsights;
 
-  // Query target user lists if profile exists and content is visible
+  // Query target user lists if profile exists, content is visible, and the relevant tab is active
   const watchlist = useQuery(
     api.watchlist.getPublicWatchlist,
-    targetUserId && showWatchlistTab && !showLockScreen
+    targetUserId &&
+      showWatchlistTab &&
+      !showLockScreen &&
+      (activeTab === "all" || activeTab === "watchlist")
       ? { userId: targetUserId }
       : "skip",
   ) as GridMediaItem[] | undefined;
   const favorites = useQuery(
     api.favorites.getPublicFavorites,
-    targetUserId && showFavoritesTab && !showLockScreen
+    targetUserId &&
+      showFavoritesTab &&
+      !showLockScreen &&
+      (activeTab === "all" || activeTab === "favorites")
       ? { userId: targetUserId }
       : "skip",
   ) as GridMediaItem[] | undefined;
   const ratings = useQuery(
     api.ratings.getUserRatings,
-    targetUserId && showRatingsTab && !showLockScreen
+    targetUserId &&
+      showRatingsTab &&
+      !showLockScreen &&
+      (activeTab === "all" || activeTab === "ratings")
       ? { userId: targetUserId }
       : "skip",
   ) as GridMediaItem[] | undefined;
   const diary = useQuery(
     api.diary.getUserDiary,
-    targetUserId && (showDiaryTab || showInsightsTab) && !showLockScreen
+    targetUserId &&
+      !showLockScreen &&
+      (showInsightsTab ||
+        (showDiaryTab && (activeTab === "all" || activeTab === "diary")))
       ? { userId: targetUserId }
       : "skip",
   ) as DiaryItem[] | undefined;
 
   const continueWatching = useQuery(
     api.continueWatching.getProgress,
-    isOwner && isLoggedIn ? {} : "skip",
+    isOwner &&
+      isLoggedIn &&
+      (activeTab === "all" || activeTab === "continue-watching")
+      ? {}
+      : "skip",
   );
 
   const handleBlockAction = async () => {
@@ -398,6 +418,15 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   // Loading states
   const loadingProfile = profileData === undefined;
 
+  const isTabLoading =
+    (activeTab === "all" &&
+      (watchlist === undefined ||
+        favorites === undefined ||
+        ratings === undefined)) ||
+    (activeTab === "watchlist" && watchlist === undefined) ||
+    (activeTab === "favorites" && favorites === undefined) ||
+    (activeTab === "ratings" && ratings === undefined);
+
   if (loadingProfile) {
     return (
       <div className="flex min-h-[50vh] grow items-center justify-center bg-zinc-950 text-white">
@@ -493,41 +522,30 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
 
   // Define tab navigation dynamically based on visitor visibility settings
   const tabsList = [
-    { id: "all" as const, label: "All", count: allItems.length, visible: true },
+    { id: "all" as const, label: "All", visible: true },
     {
-      id: "continueWatching" as const,
+      id: "continue-watching" as const,
       label: "Continue Watching",
-      count: continueWatching ? continueWatching.length : 0,
       visible: isOwner,
     },
     {
       id: "diary" as const,
       label: "Diary",
-      count: diary ? diary.length : 0,
       visible: showDiaryTab,
-    },
-    {
-      id: "insights" as const,
-      label: "Insights",
-      count: diary ? diary.length : 0,
-      visible: showInsightsTab,
     },
     {
       id: "watchlist" as const,
       label: "Watchlist",
-      count: watchlist ? watchlist.length : 0,
       visible: showWatchlistTab,
     },
     {
       id: "favorites" as const,
       label: "Favorites",
-      count: favorites ? favorites.length : 0,
       visible: showFavoritesTab,
     },
     {
       id: "ratings" as const,
       label: "Ratings",
-      count: ratings ? ratings.length : 0,
       visible: showRatingsTab,
     },
   ].filter((t) => t.visible);
@@ -554,6 +572,19 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
         <LockScreen isFriendsOnly={isFriendsOnly} />
       ) : (
         <>
+          {/* Insights (Always visible if showInsightsTab is true) */}
+          {showInsightsTab && (
+            <div className="mb-12 border-b border-zinc-900 pb-12">
+              {diary === undefined ? (
+                <div className="flex items-center justify-center py-20">
+                  <Loader2 className="text-primary h-8 w-8 animate-spin" />
+                </div>
+              ) : (
+                <InsightsTab diary={diary} user={targetUser} />
+              )}
+            </div>
+          )}
+
           {/* Tabs */}
           <div className="mb-8 flex scrollbar-none gap-6 overflow-x-auto border-b border-zinc-900 text-sm">
             {tabsList.map((tab) => (
@@ -567,7 +598,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
                     : "border-transparent text-zinc-500 hover:text-zinc-300",
                 )}
               >
-                {tab.label} ({tab.count})
+                {tab.label}
               </button>
             ))}
           </div>
@@ -596,22 +627,30 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
                 handleToggleSelectItem={handleToggleSelectItem}
               />
             </>
-          ) : activeTab === "insights" ? (
-            <InsightsTab diary={diary} user={targetUser} />
-          ) : activeTab === "continueWatching" ? (
-            <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-              {continueWatching && continueWatching.length > 0 ? (
-                continueWatching.map((item) => (
-                  <ContinueWatchingCard key={item._id} item={item} />
-                ))
-              ) : (
-                <div className="col-span-full flex min-h-[30vh] flex-col items-center justify-center text-center">
-                  <Play className="mb-4 h-12 w-12 text-zinc-800" />
-                  <p className="text-sm text-zinc-500">
-                    Your Continue Watching list is empty.
-                  </p>
-                </div>
-              )}
+          ) : activeTab === "continue-watching" ? (
+            continueWatching === undefined ? (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="text-primary h-8 w-8 animate-spin" />
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-4">
+                {continueWatching.length > 0 ? (
+                  continueWatching.map((item) => (
+                    <ContinueWatchingCard key={item._id} item={item} />
+                  ))
+                ) : (
+                  <div className="col-span-full flex min-h-[30vh] flex-col items-center justify-center text-center">
+                    <Play className="mb-4 h-12 w-12 text-zinc-800" />
+                    <p className="text-sm text-zinc-500">
+                      Your Continue Watching list is empty.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )
+          ) : isTabLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <Loader2 className="text-primary h-8 w-8 animate-spin" />
             </div>
           ) : (
             <>

--- a/components/company-detail-client.tsx
+++ b/components/company-detail-client.tsx
@@ -15,6 +15,7 @@ import {
   Info,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Card from "@/components/card";
 import QuickViewModal from "@/components/quick-view-modal";
 import AuthModal from "@/components/auth-modal";
@@ -41,6 +42,7 @@ export default function CompanyDetailClient({
   movies,
   tvShows,
 }: CompanyDetailClientProps) {
+  const router = useRouter();
   const {
     open: openAuth,
     isOpen: isAuthOpen,
@@ -111,13 +113,14 @@ export default function CompanyDetailClient({
     <div className="min-h-screen bg-black pt-20 text-white">
       <div className="relative z-10 mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
         {/* Back Link */}
-        <Link
-          href="/"
-          className="mb-8 flex w-fit items-center gap-2 text-sm font-semibold text-zinc-400 transition-colors hover:text-white"
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="mb-8 flex w-fit cursor-pointer items-center gap-2 text-sm font-semibold text-zinc-400 transition-colors hover:text-white"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Home
-        </Link>
+          Back
+        </button>
 
         {/* Company Profile Header */}
         <div className="mb-12 overflow-hidden rounded-3xl border border-zinc-800/80 bg-zinc-900/40 p-6 backdrop-blur-xl sm:p-8 md:p-10">

--- a/components/continue-watching-card.tsx
+++ b/components/continue-watching-card.tsx
@@ -14,6 +14,8 @@ interface ContinueWatchingItem {
   mediaType: string;
   title: string;
   posterPath: string;
+  backdropPath?: string;
+  episodeStillPath?: string;
   season?: number;
   episode?: number;
   updatedAt: number;
@@ -50,21 +52,45 @@ export default function ContinueWatchingCard({
     }
   };
 
-  const posterPath = item.posterPath
-    ? `${process.env.NEXT_PUBLIC_API_IMAGE_300 || "https://image.tmdb.org/t/p/w300"}${item.posterPath}`
-    : "/logo/popcorn.png";
+  let rawImage = "/logo/popcorn.png";
+
+  if (item.mediaType === "tv") {
+    // TV Series: Prioritize episode still image, then backdrop, then poster
+    const still = item.episodeStillPath || item.backdropPath || item.posterPath;
+    if (still) {
+      rawImage = `${process.env.NEXT_PUBLIC_API_IMAGE_500 || "https://image.tmdb.org/t/p/w500"}${still}`;
+    }
+  } else {
+    // Movie: Prioritize backdrop image, then poster
+    const backdrop = item.backdropPath || item.posterPath;
+    if (backdrop) {
+      rawImage = `${process.env.NEXT_PUBLIC_API_IMAGE_500 || "https://image.tmdb.org/t/p/w500"}${backdrop}`;
+    }
+  }
+
+  const imagePath = rawImage;
 
   const relativeTime = moment(item.updatedAt).fromNow();
 
   return (
     <div
-      onClick={() => router.push(`/${item.mediaType}/${item.mediaId}`)}
+      onClick={() => {
+        const queryParams = new URLSearchParams();
+        queryParams.set("playTab", "watch");
+        if (item.season !== undefined) {
+          queryParams.set("season", String(item.season));
+        }
+        if (item.episode !== undefined) {
+          queryParams.set("episode", String(item.episode));
+        }
+        router.push(`/${item.mediaType}/${item.mediaId}?${queryParams.toString()}`, { scroll: false });
+      }}
       className="group relative flex w-full shrink-0 cursor-pointer flex-col gap-3 overflow-hidden rounded-2xl transition-all duration-300 md:hover:-translate-y-1"
     >
-      {/* Poster area */}
-      <div className="relative aspect-2/3 w-full overflow-hidden rounded-2xl border border-zinc-800/40 bg-zinc-900">
+      {/* Backdrop area (Landscape) */}
+      <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-zinc-800/40 bg-zinc-900">
         <img
-          src={posterPath}
+          src={imagePath}
           alt={item.title}
           className="h-full w-full object-cover transition-transform duration-500 md:group-hover:scale-105"
           loading="lazy"

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -298,11 +298,33 @@ export default function Hero({
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
 
+  const [initialIndex] = useState(() => {
+    if (typeof window !== "undefined") {
+      const saved = sessionStorage.getItem("hero_active_index");
+      if (saved !== null) {
+        const parsed = parseInt(saved, 10);
+        if (!isNaN(parsed) && parsed >= 0 && parsed < (items?.length || 0)) {
+          return parsed;
+        }
+      }
+    }
+    return 0;
+  });
+
   if (!items || items.length === 0) return null;
 
   return (
     <div className="relative h-[90svh] w-full overflow-hidden bg-zinc-950 select-none sm:h-svh">
       <Swiper
+        initialSlide={initialIndex}
+        onSwiper={(swiper) => {
+          if (initialIndex > 0) {
+            swiper.slideToLoop(initialIndex, 0);
+          }
+        }}
+        onSlideChange={(swiper) => {
+          sessionStorage.setItem("hero_active_index", String(swiper.realIndex));
+        }}
         modules={[Autoplay, Pagination, EffectFade]}
         effect="fade"
         pagination={{ clickable: true }}

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -18,8 +18,11 @@ import ContinueWatchingCard from "./continue-watching-card";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import { FreeMode, Mousewheel } from "swiper/modules";
-import { Play, Bookmark } from "lucide-react";
-import { CarouselSkeleton } from "./skeletons";
+import {
+  CarouselSkeleton,
+  ContinueWatchingCarouselSkeleton,
+  Skeleton,
+} from "./skeletons";
 import Card from "./card";
 
 interface HomeClientProps {
@@ -67,12 +70,58 @@ export default function HomeClient({
         <div className="bg-background relative z-20 flex flex-col gap-6 pb-20 transition-colors duration-300">
           {/* Continue Watching Section */}
           {isLoggedIn &&
-            continueWatching !== undefined &&
-            continueWatching.length > 0 && (
+            (continueWatching === undefined ? (
               <div className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-44 rounded-md" />
+                </div>
+                <ContinueWatchingCarouselSkeleton />
+              </div>
+            ) : continueWatching.length > 0 ? (
+              <div className="animate-in fade-in flex w-full flex-col gap-6 px-6 py-6 duration-300 sm:px-16 md:px-20">
                 <h2 className="flex items-center gap-2 text-xl font-bold tracking-tight text-white sm:text-2xl">
-                  <Play className="text-primary h-5 w-5 fill-current" />
                   Continue Watching
+                </h2>
+                <div className="swiper-carousel-container relative w-full">
+                  <Swiper
+                    modules={[Mousewheel, FreeMode]}
+                    freeMode={true}
+                    spaceBetween={16}
+                    slidesPerView={1.3}
+                    breakpoints={{
+                      640: { slidesPerView: 1.2, spaceBetween: 20 },
+                      768: { slidesPerView: 2.7, spaceBetween: 24 },
+                      1024: { slidesPerView: 3.7, spaceBetween: 24 },
+                      1280: { slidesPerView: 4, spaceBetween: 24 },
+                    }}
+                    mousewheel={{
+                      forceToAxis: true,
+                    }}
+                    className="w-full pb-4"
+                  >
+                    {continueWatching.map((item) => (
+                      <SwiperSlide key={item._id} className="py-1">
+                        <ContinueWatchingCard item={item} />
+                      </SwiperSlide>
+                    ))}
+                  </Swiper>
+                </div>
+              </div>
+            ) : null)}
+
+          {/* Watchlist Section */}
+          {isLoggedIn &&
+            (watchlist === undefined ? (
+              <div className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-36 rounded-md" />
+                </div>
+                <CarouselSkeleton />
+              </div>
+            ) : watchlist.length > 0 ? (
+              <div className="animate-in fade-in flex w-full flex-col gap-6 px-6 py-6 duration-300 sm:px-16 md:px-20">
+                <h2 className="flex items-center gap-2 text-xl font-bold tracking-tight text-white sm:text-2xl">
+                  My Watchlist
                 </h2>
                 <div className="swiper-carousel-container relative w-full">
                   <Swiper
@@ -91,68 +140,34 @@ export default function HomeClient({
                     }}
                     className="w-full pb-4"
                   >
-                    {continueWatching.map((item) => (
-                      <SwiperSlide key={item._id} className="py-1">
-                        <ContinueWatchingCard item={item} />
-                      </SwiperSlide>
-                    ))}
+                    {watchlist.map((item) => {
+                      const mediaItem: TMDBMedia = {
+                        id: Number(item.mediaId),
+                        media_type: item.mediaType as "movie" | "tv",
+                        title: item.title,
+                        name: item.title,
+                        poster_path: item.posterPath,
+                        vote_average: item.rating || 0,
+                        release_date: item.releaseYear,
+                        backdrop_path: "",
+                        genre_ids: [],
+                        overview: "",
+                        popularity: 0,
+                      };
+                      return (
+                        <SwiperSlide key={item._id} className="py-1">
+                          <Card
+                            media={mediaItem}
+                            onQuickView={handleQuickView}
+                            onAuthRequired={openAuth}
+                          />
+                        </SwiperSlide>
+                      );
+                    })}
                   </Swiper>
                 </div>
               </div>
-            )}
-
-          {/* Watchlist Section */}
-          {isLoggedIn && watchlist !== undefined && watchlist.length > 0 && (
-            <div className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20">
-              <h2 className="flex items-center gap-2 text-xl font-bold tracking-tight text-white sm:text-2xl">
-                <Bookmark className="text-primary h-5 w-5 fill-current" />
-                My Watchlist
-              </h2>
-              <div className="swiper-carousel-container relative w-full">
-                <Swiper
-                  modules={[Mousewheel, FreeMode]}
-                  freeMode={true}
-                  spaceBetween={16}
-                  slidesPerView={2}
-                  breakpoints={{
-                    640: { slidesPerView: 3, spaceBetween: 24 },
-                    768: { slidesPerView: 4, spaceBetween: 24 },
-                    1024: { slidesPerView: 5, spaceBetween: 24 },
-                    1280: { slidesPerView: 6, spaceBetween: 24 },
-                  }}
-                  mousewheel={{
-                    forceToAxis: true,
-                  }}
-                  className="w-full pb-4"
-                >
-                  {watchlist.map((item) => {
-                    const mediaItem: TMDBMedia = {
-                      id: Number(item.mediaId),
-                      media_type: item.mediaType as "movie" | "tv",
-                      title: item.title,
-                      name: item.title,
-                      poster_path: item.posterPath,
-                      vote_average: item.rating || 0,
-                      release_date: item.releaseYear,
-                      backdrop_path: "",
-                      genre_ids: [],
-                      overview: "",
-                      popularity: 0,
-                    };
-                    return (
-                      <SwiperSlide key={item._id} className="py-1">
-                        <Card
-                          media={mediaItem}
-                          onQuickView={handleQuickView}
-                          onAuthRequired={openAuth}
-                        />
-                      </SwiperSlide>
-                    );
-                  })}
-                </Swiper>
-              </div>
-            </div>
-          )}
+            ) : null)}
 
           {/* Trending Now */}
           <div id="trending">

--- a/components/media-detail-client.tsx
+++ b/components/media-detail-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { authClient } from "@/lib/auth-client";
@@ -134,10 +135,29 @@ export default function MediaDetailClient({
   const [now] = useState(() => Date.now());
 
   // Player tabs & selections
-  const [activeTab, setActiveTab] = useState<"trailer" | "watch">("trailer");
+  const [activeTabState, setActiveTabState] = useQueryState("playTab", {
+    defaultValue: "trailer",
+  });
+  const activeTab = (activeTabState === "watch" ? "watch" : "trailer") as
+    | "trailer"
+    | "watch";
+  const setActiveTab = (tab: "trailer" | "watch") => {
+    setActiveTabState(tab);
+  };
+
   const [selectedServer, setSelectedServer] = useState<number>(0);
-  const [season, setSeason] = useState(1);
-  const [episode, setEpisode] = useState(1);
+
+  const [seasonState, setSeasonState] = useQueryState("season");
+  const season = seasonState ? parseInt(seasonState) || 1 : 1;
+  const setSeason = (s: number) => {
+    setSeasonState(String(s));
+  };
+
+  const [episodeState, setEpisodeState] = useQueryState("episode");
+  const episode = episodeState ? parseInt(episodeState) || 1 : 1;
+  const setEpisode = (e: number) => {
+    setEpisodeState(String(e));
+  };
   const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
   const [quickViewPersonId, setQuickViewPersonId] = useState<number | null>(
     null,
@@ -355,7 +375,45 @@ export default function MediaDetailClient({
         }
       });
     }
-  }, [watchProgress]);
+  }, [watchProgress, setSeason, setEpisode]);
+
+  // Scroll player section into view on mount if playTab query param is "watch"
+  const hasScrolledOnMount = useRef(false);
+  useEffect(() => {
+    if (activeTabState === "watch" && !hasScrolledOnMount.current) {
+      const timer = setTimeout(() => {
+        if (playerSectionRef.current) {
+          hasScrolledOnMount.current = true;
+          playerSectionRef.current.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [activeTabState]);
+
+  // Fetch active season details automatically for TV series
+  useEffect(() => {
+    if (mediaType === "tv" && details?.id && season) {
+      getSeasonDetails(details.id, season).then((data) => {
+        if (data) {
+          setActiveSeasonData(data as SeasonDetails);
+        }
+      });
+    }
+  }, [mediaType, details?.id, season]);
+
+  const currentEpisodeStill = useMemo(() => {
+    if (mediaType === "tv" && activeSeasonData && activeSeasonData.episodes) {
+      const epObj = activeSeasonData.episodes.find(
+        (e) => e.episode_number === episode,
+      );
+      return epObj?.still_path || undefined;
+    }
+    return undefined;
+  }, [mediaType, activeSeasonData, episode]);
 
   // Track and save watch progress
   useEffect(() => {
@@ -365,6 +423,8 @@ export default function MediaDetailClient({
         mediaType,
         title: details.title || details.name || "",
         posterPath: details.poster_path || "",
+        backdropPath: details.backdrop_path || undefined,
+        episodeStillPath: currentEpisodeStill,
         season: mediaType === "tv" ? season : undefined,
         episode: mediaType === "tv" ? episode : undefined,
       }).catch((err) => console.error("Failed to save watch progress:", err));
@@ -376,6 +436,7 @@ export default function MediaDetailClient({
     isLoggedIn,
     mediaType,
     details,
+    currentEpisodeStill,
     upsertWatchProgress,
   ]);
 

--- a/components/media-detail/video-player.tsx
+++ b/components/media-detail/video-player.tsx
@@ -266,7 +266,7 @@ export default function VideoPlayer({
       <div className="border-t border-zinc-800/80 bg-zinc-900/40 p-4 text-center text-xs text-zinc-400">
         {activeTab === "watch"
           ? "Tip: Enable an ad-blocker extension in your browser to prevent popup ads from third-party streaming providers."
-          : "Now displaying the official trailer. Click 'Watch Movie/Show' to stream."}
+          : "Now displaying the official trailer. Click 'Watch Movie/TV Show' to stream."}
       </div>
     </div>
   );

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -222,15 +222,7 @@ export default function Navbar() {
           )}
 
           {/* User Controls (Desktop) */}
-          <div className="hidden items-center gap-4 justify-self-end lg:flex">
-            <Link
-              href="/feed"
-              prefetch={false}
-              className="relative cursor-pointer rounded-full border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-all hover:border-zinc-700 hover:text-white focus:outline-none"
-              title="Activity Feed"
-            >
-              <Activity className="h-4 w-4" />
-            </Link>
+          <div className="hidden items-center gap-2 justify-self-end lg:flex">
             {isLoggedIn && (
               <>
                 <DropdownMenu>
@@ -592,6 +584,17 @@ export default function Navbar() {
                     <MessageSquare className="mr-2 h-4 w-4 text-zinc-400" />
                     Chats
                   </DropdownMenuItem>
+
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setDropdownMenuOpen(false);
+                      router.push("/feed");
+                    }}
+                    className="cursor-pointer rounded-xl px-3 py-2 text-zinc-300 hover:bg-zinc-800 hover:text-white focus:bg-zinc-800 focus:text-white"
+                  >
+                    <Activity className="mr-2 h-4 w-4 text-zinc-400" />
+                    Feed
+                  </DropdownMenuItem>
                   {(userProfile?.role === "owner" ||
                     userProfile?.role === "admin") && (
                     <>
@@ -662,7 +665,7 @@ export default function Navbar() {
             {isLoggedIn && (
               <>
                 <DropdownMenu>
-                  <DropdownMenuTrigger className="hover:border-zinc-705 relative cursor-pointer rounded-xl border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-all hover:text-white focus:outline-none">
+                  <DropdownMenuTrigger className="hover:border-zinc-705 relative cursor-pointer rounded-full border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-all hover:text-white focus:outline-none">
                     <Bell className="h-5 w-5" />
                     {unreadCount > 0 && (
                       <span className="ring-background bg-primary absolute -top-1 -right-1 flex h-4.5 w-4.5 items-center justify-center rounded-full text-[8px] font-black text-white ring-2">
@@ -964,7 +967,7 @@ export default function Navbar() {
 
             {/* Mobile Menu Button & Drawer via Shadcn Sheet */}
             <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-              <SheetTrigger className="border-zinc-805 cursor-pointer rounded-xl border bg-zinc-900/60 p-2 text-zinc-300 hover:text-white">
+              <SheetTrigger className="border-zinc-805 cursor-pointer rounded-full border bg-zinc-900/60 p-2 text-zinc-300 hover:text-white">
                 <Menu className="h-6 w-6" />
               </SheetTrigger>
               <SheetContent

--- a/components/person-detail-client.tsx
+++ b/components/person-detail-client.tsx
@@ -14,6 +14,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import Card from "@/components/card";
 import QuickViewModal from "@/components/quick-view-modal";
@@ -64,6 +65,7 @@ export default function PersonDetailClient({
   person,
   credits,
 }: PersonDetailClientProps) {
+  const router = useRouter();
   const {
     open: openAuth,
     isOpen: isAuthOpen,
@@ -187,13 +189,14 @@ export default function PersonDetailClient({
     <main className="bg-background text-foreground min-h-svh pt-24 pb-16 transition-colors duration-300">
       <div className="mx-auto max-w-7xl px-6 sm:px-10 md:px-16">
         {/* Back Link */}
-        <Link
-          href="/"
-          className="mb-8 flex w-fit items-center gap-2 text-sm font-semibold text-zinc-400 transition-colors hover:text-white"
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="mb-8 flex w-fit cursor-pointer items-center gap-2 text-sm font-semibold text-zinc-400 transition-colors hover:text-white"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Home
-        </Link>
+          Back
+        </button>
 
         {/* Profile Header Grid */}
         <div className="grid grid-cols-1 gap-10 md:grid-cols-[280px_1fr] lg:gap-16">

--- a/components/profile/insights-tab.tsx
+++ b/components/profile/insights-tab.tsx
@@ -41,11 +41,11 @@ import {
   Clock,
   Star,
   Loader2,
-  Sparkles,
   TrendingUp,
   User,
   Video,
   Tv2,
+  ChartPie,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -417,7 +417,7 @@ export function InsightsTab({ diary, user }: InsightsTabProps) {
   if (!diary || diary.length === 0) {
     return (
       <div className="flex min-h-[30vh] flex-col items-center justify-center text-center">
-        <Sparkles className="mb-4 h-12 w-12 text-zinc-800" />
+        <ChartPie className="mb-4 h-12 w-12 text-zinc-800" />
         <p className="text-sm text-zinc-500">
           No watch history available. Log titles to your diary to view
           statistics and insights.

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -7,6 +7,7 @@ import { authClient } from "@/lib/auth-client";
 import { TooltipProvider } from "./ui/tooltip";
 import { PersonalizationProvider } from "./theme-provider";
 import { ConfirmProvider } from "./ui/confirm-provider";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
@@ -16,7 +17,9 @@ export function Providers({ children }: { children: ReactNode }) {
       <ConvexBetterAuthProvider client={convex} authClient={authClient}>
         <PersonalizationProvider>
           <ConfirmProvider>
-            <TooltipProvider>{children}</TooltipProvider>
+            <TooltipProvider>
+              <NuqsAdapter>{children}</NuqsAdapter>
+            </TooltipProvider>
           </ConfirmProvider>
         </PersonalizationProvider>
       </ConvexBetterAuthProvider>

--- a/components/quick-view-modal.tsx
+++ b/components/quick-view-modal.tsx
@@ -18,6 +18,7 @@ import {
   Plus,
   Check,
   Heart,
+  Play,
 } from "lucide-react";
 import {
   Dialog,
@@ -331,8 +332,22 @@ export default function QuickViewModal({
                 )}
               </div>
 
-              {/* Watchlist & Favorite Buttons */}
+              {/* Action Buttons: View Details, Watchlist & Favorite */}
               <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  onClick={() => {
+                    onClose();
+                    const mType = media.media_type || "movie";
+                    router.push(`/${mType}/${media.id}`);
+                  }}
+                  className="bg-primary hover:bg-primary/90 h-9 cursor-pointer rounded-full px-4 py-4 text-xs font-semibold text-white shadow-lg shadow-red-950/40 transition-all hover:scale-105 active:scale-98"
+                >
+                  <span className="flex items-center gap-1.5">
+                    <Play className="h-3.5 w-3.5 fill-current" />
+                    View Details
+                  </span>
+                </Button>
+
                 <Button
                   onClick={handleWatchlistToggle}
                   disabled={watchlistLoading}

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -47,17 +47,67 @@ export default function Section({
   const [loading, setLoading] = useState(true);
 
   // States for interactive controls
-  const [trendingTab, setTrendingTab] = useState<"all" | "movie" | "tv">("all");
-  const [streamingProv, setStreamingProv] =
-    useState<keyof typeof PROVIDERS>("netflix");
-  const [genreName, setGenreName] = useState<string>("Action");
+  const [trendingTab, setTrendingTab] = useState<"all" | "movie" | "tv">(() => {
+    if (titleType === "text" && typeof window !== "undefined") {
+      const saved = sessionStorage.getItem("trending_tab");
+      if (saved === "all" || saved === "movie" || saved === "tv") {
+        return saved;
+      }
+    }
+    return "all";
+  });
+  const [streamingProv, setStreamingProv] = useState<keyof typeof PROVIDERS>(
+    () => {
+      if (titleType === "dropdown-streaming" && typeof window !== "undefined") {
+        const saved = sessionStorage.getItem("streaming_prov");
+        if (saved && saved in PROVIDERS) {
+          return saved as keyof typeof PROVIDERS;
+        }
+      }
+      return "netflix";
+    },
+  );
+  const [genreName, setGenreName] = useState<string>(() => {
+    if (titleType === "dropdown-genre" && typeof window !== "undefined") {
+      const saved = sessionStorage.getItem("genre_name");
+      if (saved) {
+        return saved;
+      }
+    }
+    return "Action";
+  });
 
   // Fetch initial data
   useEffect(() => {
-    defaultFetch().then((data) => {
-      setItems(data);
-      setLoading(false);
-    });
+    if (titleType === "text" && trendingTab !== "all" && onTrendingChange) {
+      onTrendingChange(trendingTab).then((data) => {
+        setItems(data);
+        setLoading(false);
+      });
+    } else if (
+      titleType === "dropdown-streaming" &&
+      streamingProv !== "netflix" &&
+      onStreamingChange
+    ) {
+      onStreamingChange(streamingProv).then((data) => {
+        setItems(data);
+        setLoading(false);
+      });
+    } else if (
+      titleType === "dropdown-genre" &&
+      genreName !== "Action" &&
+      onGenreChange
+    ) {
+      onGenreChange(genreName).then((data) => {
+        setItems(data);
+        setLoading(false);
+      });
+    } else {
+      defaultFetch().then((data) => {
+        setItems(data);
+        setLoading(false);
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -65,6 +115,9 @@ export default function Section({
   const handleTrendingChange = async (type: "all" | "movie" | "tv") => {
     if (!onTrendingChange) return;
     setTrendingTab(type);
+    if (titleType === "text") {
+      sessionStorage.setItem("trending_tab", type);
+    }
     setLoading(true);
     const data = await onTrendingChange(type);
     setItems(data);
@@ -74,6 +127,9 @@ export default function Section({
   const handleStreamingChange = async (prov: keyof typeof PROVIDERS) => {
     if (!onStreamingChange) return;
     setStreamingProv(prov);
+    if (titleType === "dropdown-streaming") {
+      sessionStorage.setItem("streaming_prov", prov);
+    }
     setLoading(true);
     const data = await onStreamingChange(prov);
     setItems(data);
@@ -83,6 +139,9 @@ export default function Section({
   const handleGenreChange = async (name: string) => {
     if (!onGenreChange) return;
     setGenreName(name);
+    if (titleType === "dropdown-genre") {
+      sessionStorage.setItem("genre_name", name);
+    }
     setLoading(true);
     const data = await onGenreChange(name);
     setItems(data);

--- a/components/skeletons.tsx
+++ b/components/skeletons.tsx
@@ -109,14 +109,14 @@ export function CarouselSkeleton() {
 export function ContinueWatchingCardSkeleton() {
   return (
     <div className="flex w-full shrink-0 flex-col gap-3">
-      {/* Poster area */}
-      <div className="relative aspect-2/3 w-full overflow-hidden rounded-2xl border border-zinc-800/40 bg-zinc-900">
+      {/* Backdrop area (Landscape) */}
+      <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-zinc-800/40 bg-zinc-900">
         <Skeleton className="h-full w-full rounded-none" />
       </div>
       {/* Info / Metadata */}
       <div className="flex flex-col gap-1.5 px-1">
         <Skeleton className="h-4 w-11/12 rounded" />
-        <Skeleton className="h-3.5 w-1/3 rounded-sm bg-primary/25" />
+        <Skeleton className="bg-primary/25 h-3.5 w-1/3 rounded-sm" />
         <Skeleton className="h-3 w-1/2 rounded-sm" />
       </div>
     </div>
@@ -129,12 +129,12 @@ export function ContinueWatchingCarouselSkeleton() {
     <div className="swiper-carousel-container relative w-full">
       <Swiper
         spaceBetween={16}
-        slidesPerView={2}
+        slidesPerView={1.3}
         breakpoints={{
-          640: { slidesPerView: 3, spaceBetween: 24 },
-          768: { slidesPerView: 4, spaceBetween: 24 },
-          1024: { slidesPerView: 5, spaceBetween: 24 },
-          1280: { slidesPerView: 6, spaceBetween: 24 },
+          640: { slidesPerView: 1.2, spaceBetween: 20 },
+          768: { slidesPerView: 2.7, spaceBetween: 24 },
+          1024: { slidesPerView: 3.7, spaceBetween: 24 },
+          1280: { slidesPerView: 4, spaceBetween: 24 },
         }}
         className="w-full pb-4"
         allowTouchMove={false}
@@ -148,4 +148,3 @@ export function ContinueWatchingCarouselSkeleton() {
     </div>
   );
 }
-

--- a/convex/continueWatching.ts
+++ b/convex/continueWatching.ts
@@ -9,6 +9,8 @@ export const upsertProgress = mutation({
     mediaType: v.string(), // "movie" or "tv"
     title: v.string(),
     posterPath: v.string(),
+    backdropPath: v.optional(v.string()),
+    episodeStillPath: v.optional(v.string()),
     season: v.optional(v.number()),
     episode: v.optional(v.number()),
   },
@@ -26,6 +28,8 @@ export const upsertProgress = mutation({
 
     if (existing) {
       await ctx.db.patch(existing._id, {
+        backdropPath: args.backdropPath,
+        episodeStillPath: args.episodeStillPath,
         season: args.season,
         episode: args.episode,
         updatedAt: Date.now(),
@@ -40,6 +44,8 @@ export const upsertProgress = mutation({
       mediaType: args.mediaType,
       title: args.title,
       posterPath: args.posterPath,
+      backdropPath: args.backdropPath,
+      episodeStillPath: args.episodeStillPath,
       season: args.season,
       episode: args.episode,
       updatedAt: Date.now(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -205,6 +205,8 @@ export default defineSchema({
     mediaType: v.string(),
     title: v.string(),
     posterPath: v.string(),
+    backdropPath: v.optional(v.string()),
+    episodeStillPath: v.optional(v.string()),
     season: v.optional(v.number()),
     episode: v.optional(v.number()),
     updatedAt: v.number(),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "moment": "^2.30.1",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.9.4",
     "pluralize": "^8.0.0",
     "react": "19.2.4",
     "react-day-picker": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      nuqs:
+        specifier: ^2.9.4
+        version: 2.9.4(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
@@ -3151,6 +3154,27 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nuqs@2.9.4:
+    resolution: {integrity: sha512-lsz3NyCOKmuNAyW052i9RWqcTntoYb2Qm6FxSWnkTDwOJnGS6fzpXDAp0VcwTevw3xgnWebYpDr9rm6+o4DHbw==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7 || ^8
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6996,6 +7020,13 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nuqs@2.9.4(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      react: 19.2.4
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
- Refactor Continue Watching cards to landscape layout (16:9 aspect-video).
- Update Continue Watching images to prioritize TMDB backdrops for movies and episode stills for TV series (incorporating auto TV season details fetch).
- Integrate direct navigation from Continue Watching cards to video player with automatic scroll-to-view and `scroll: false` router options.
- Persist active states for Trending Now, Streaming Originals, and Genres dropdowns in sessionStorage to maintain selections on back navigation.
- Implement URL-backed state using `nuqs` for user profile tabs and media detail player tabs (trailer/watch).
- Add loading skeletons and spinners to My Watchlist section and profile tabs to prevent layout shifts.
- Move Feed button inside Profile Dropdown and unify mobile Navbar buttons styling to `rounded-full`.
- Replace "Back to Home" links in Company & Person pages with standard `router.back()` actions.
- Resolve React Compiler & linter warnings regarding synchronous state updates and mutable ref accesses inside useEffect.