### PR TITLE
feat: migrate routes to client-side fetching with skeleton loaders

### DIFF
--- a/app/(main)/company/[id]/page.tsx
+++ b/app/(main)/company/[id]/page.tsx
@@ -1,10 +1,5 @@
 import { Metadata } from "next";
-import {
-  getCompanyDetails,
-  getCompanyMovies,
-  getCompanyTVShows,
-} from "@/lib/tmdb-actions";
-import { notFound } from "next/navigation";
+import { getCompanyDetails } from "@/lib/tmdb-actions";
 import { siteConfig } from "@/config/site";
 import CompanyDetailClient from "@/components/company-detail-client";
 
@@ -39,22 +34,5 @@ export async function generateMetadata({
 
 export default async function CompanyDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const company = await getCompanyDetails(id);
-
-  if (!company) {
-    notFound();
-  }
-
-  const [movies, tvShows] = await Promise.all([
-    getCompanyMovies(id),
-    getCompanyTVShows(id),
-  ]);
-
-  return (
-    <CompanyDetailClient
-      company={company}
-      movies={movies}
-      tvShows={tvShows}
-    />
-  );
+  return <CompanyDetailClient id={id} />;
 }

--- a/app/(main)/movie/[id]/page.tsx
+++ b/app/(main)/movie/[id]/page.tsx
@@ -1,22 +1,17 @@
 import { Metadata } from "next";
 import { getMediaDetails } from "@/lib/tmdb-actions";
-import { notFound } from "next/navigation";
-import MediaDetailClient from "@/components/media-detail-client";
 import { siteConfig } from "@/config/site";
+import MediaDetailClient from "@/components/media-detail-client";
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: PageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
   const data = await getMediaDetails("movie", id);
   if (!data || !data.details) {
-    return {
-      title: `Movie Not Found | ${siteConfig.name}`,
-    };
+    return { title: `Movie Not Found | ${siteConfig.name}` };
   }
   const movie = data.details;
   const releaseYear = movie.release_date
@@ -39,11 +34,5 @@ export async function generateMetadata({
 
 export default async function MovieDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const mediaData = await getMediaDetails("movie", id);
-
-  if (!mediaData || !mediaData.details) {
-    notFound();
-  }
-
-  return <MediaDetailClient mediaType="movie" initialData={mediaData} />;
+  return <MediaDetailClient mediaType="movie" id={id} />;
 }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,28 +1,11 @@
 import HomeClient from "@/components/home-client";
-import {
-  getHeroItems,
-  getTrending,
-  getStreamingOriginals,
-  getByCategory,
-} from "@/lib/tmdb-actions";
 
-export const revalidate = 3600; // Revalidate every hour
+export const metadata = {
+  title: "PopcornVision — Watch Movies & TV Shows Free",
+  description:
+    "Discover, track, and watch movies and TV shows for free on PopcornVision.",
+};
 
-export default async function Page() {
-  const [heroItems, trendingItems, streamingItems, categoryItems] =
-    await Promise.all([
-      getHeroItems(),
-      getTrending("all"),
-      getStreamingOriginals("netflix"),
-      getByCategory("Action"),
-    ]);
-
-  return (
-    <HomeClient
-      initialHero={heroItems}
-      initialTrending={trendingItems}
-      initialStreaming={streamingItems}
-      initialGenre={categoryItems}
-    />
-  );
+export default function Page() {
+  return <HomeClient />;
 }

--- a/app/(main)/person/[id]/page.tsx
+++ b/app/(main)/person/[id]/page.tsx
@@ -1,23 +1,17 @@
 import { Metadata } from "next";
-import { getPersonDetails, getPersonCredits } from "@/lib/tmdb-actions";
-import { notFound } from "next/navigation";
+import { getPersonDetails } from "@/lib/tmdb-actions";
 import { siteConfig } from "@/config/site";
 import PersonDetailClient from "@/components/person-detail-client";
 
-// Page props interface
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: PageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
   const person = await getPersonDetails(id);
   if (!person) {
-    return {
-      title: `Person Not Found | ${siteConfig.name}`,
-    };
+    return { title: `Person Not Found | ${siteConfig.name}` };
   }
   return {
     title: `${person.name} - Filmography & Biography | ${siteConfig.name}`,
@@ -36,12 +30,5 @@ export async function generateMetadata({
 
 export default async function PersonDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const person = await getPersonDetails(id);
-  const credits = await getPersonCredits(id);
-
-  if (!person) {
-    notFound();
-  }
-
-  return <PersonDetailClient person={person} credits={credits} />;
+  return <PersonDetailClient id={id} />;
 }

--- a/app/(main)/search/page.tsx
+++ b/app/(main)/search/page.tsx
@@ -1,15 +1,6 @@
 import SearchClient from "@/components/search-client";
 import { siteConfig } from "@/config/site";
-import { TMDBMedia } from "@/lib/tmdb";
-import {
-  searchMedia,
-  discoverMedia,
-  getTMDBGenres,
-  getTMDBProviders,
-} from "@/lib/tmdb-actions";
-import { fetchAuthQuery } from "@/lib/auth-server";
-import { api } from "@/convex/_generated/api";
-import isoCountries from "@/data/iso-3166.json";
+import { SearchType } from "@/components/search/types";
 
 interface SearchPageProps {
   searchParams: Promise<{
@@ -43,31 +34,9 @@ export async function generateMetadata({ searchParams }: SearchPageProps) {
 }
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  const user = await fetchAuthQuery(api.users.getCurrentUser).catch(() => null);
-
-  let countryCode = "US";
-  if (user?.country) {
-    const countryKey = user.country.toLowerCase();
-    const countryObj = isoCountries.find(
-      (c) =>
-        c.name?.toLowerCase() === countryKey ||
-        c["alpha-2"]?.toLowerCase() === countryKey
-    );
-    if (countryObj && countryObj["alpha-2"]) {
-      countryCode = countryObj["alpha-2"].toUpperCase();
-    } else {
-      countryCode = user.country.toUpperCase();
-    }
-  }
-
-  const [genres, providers] = await Promise.all([
-    getTMDBGenres(),
-    getTMDBProviders(countryCode),
-  ]);
-
   const params = await searchParams;
   const query = params.q || "";
-  const type = (params.type as "movie" | "tv" | "users") || "movie";
+  const type = (params.type as SearchType) || "movie";
   const genre = params.genre || "";
   const startDate = params.startDate || "";
   const endDate = params.endDate || "";
@@ -82,35 +51,8 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   const language = params.language || "";
   const keywords = params.keywords || "";
 
-  let results: TMDBMedia[] = [];
-  if (query && type !== "users") {
-    results = await searchMedia(query, type);
-  } else if (type !== "users") {
-    results = await discoverMedia(
-      {
-        genre,
-        startDate,
-        endDate,
-        providerId,
-        minRuntime,
-        maxRuntime,
-        actor,
-        crew,
-        company,
-        ratingMin,
-        ratingMax,
-        language,
-        keywords,
-      },
-      type,
-      1,
-      countryCode
-    );
-  }
-
   return (
     <SearchClient
-      initialResults={results}
       initialQuery={query}
       initialType={type}
       initialGenre={genre}
@@ -126,9 +68,6 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
       initialRatingMax={ratingMax}
       initialLanguage={language}
       initialKeywords={keywords}
-      genres={genres}
-      providers={providers}
-      userCountryCode={countryCode}
     />
   );
 }

--- a/app/(main)/tv/[id]/page.tsx
+++ b/app/(main)/tv/[id]/page.tsx
@@ -1,22 +1,17 @@
 import { Metadata } from "next";
 import { getMediaDetails } from "@/lib/tmdb-actions";
-import { notFound } from "next/navigation";
-import MediaDetailClient from "@/components/media-detail-client";
 import { siteConfig } from "@/config/site";
+import MediaDetailClient from "@/components/media-detail-client";
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: PageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
   const data = await getMediaDetails("tv", id);
   if (!data || !data.details) {
-    return {
-      title: `TV Show Not Found | ${siteConfig.name}`,
-    };
+    return { title: `TV Show Not Found | ${siteConfig.name}` };
   }
   const show = data.details;
   const releaseYear = show.first_air_date
@@ -39,11 +34,5 @@ export async function generateMetadata({
 
 export default async function TvDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const mediaData = await getMediaDetails("tv", id);
-
-  if (!mediaData || !mediaData.details) {
-    notFound();
-  }
-
-  return <MediaDetailClient mediaType="tv" initialData={mediaData} />;
+  return <MediaDetailClient mediaType="tv" id={id} />;
 }

--- a/app/api/tmdb/company/[id]/route.ts
+++ b/app/api/tmdb/company/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import {
+  getCompanyDetails,
+  getCompanyMovies,
+  getCompanyTVShows,
+} from "@/lib/tmdb-actions";
+
+export const revalidate = 3600;
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, { params }: RouteParams) {
+  const { id } = await params;
+
+  const [company, movies, tvShows] = await Promise.all([
+    getCompanyDetails(id),
+    getCompanyMovies(id),
+    getCompanyTVShows(id),
+  ]);
+
+  if (!company) {
+    return NextResponse.json({ error: "Company not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ company, movies, tvShows });
+}

--- a/app/api/tmdb/home/route.ts
+++ b/app/api/tmdb/home/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import {
+  getHeroItems,
+  getTrending,
+  getStreamingOriginals,
+  getByCategory,
+} from "@/lib/tmdb-actions";
+
+export const revalidate = 3600;
+
+export async function GET() {
+  try {
+    const [hero, trending, streaming, category] = await Promise.all([
+      getHeroItems(),
+      getTrending("all"),
+      getStreamingOriginals("netflix"),
+      getByCategory("Action"),
+    ]);
+
+    return NextResponse.json({ hero, trending, streaming, category });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch home data" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tmdb/media/[type]/[id]/route.ts
+++ b/app/api/tmdb/media/[type]/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getMediaDetails } from "@/lib/tmdb-actions";
+
+export const revalidate = 3600;
+
+interface RouteParams {
+  params: Promise<{ type: string; id: string }>;
+}
+
+export async function GET(_req: Request, { params }: RouteParams) {
+  const { type, id } = await params;
+
+  if (type !== "movie" && type !== "tv") {
+    return NextResponse.json({ error: "Invalid media type" }, { status: 400 });
+  }
+
+  const data = await getMediaDetails(type, id);
+
+  if (!data) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/app/api/tmdb/person/[id]/route.ts
+++ b/app/api/tmdb/person/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getPersonDetails, getPersonCredits } from "@/lib/tmdb-actions";
+
+export const revalidate = 3600;
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, { params }: RouteParams) {
+  const { id } = await params;
+
+  const [person, credits] = await Promise.all([
+    getPersonDetails(id),
+    getPersonCredits(id),
+  ]);
+
+  if (!person) {
+    return NextResponse.json({ error: "Person not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ person, credits });
+}

--- a/app/api/tmdb/search/meta/route.ts
+++ b/app/api/tmdb/search/meta/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getTMDBGenres, getTMDBProviders } from "@/lib/tmdb-actions";
+
+export const revalidate = 86400; // 1 day — genres & providers rarely change
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const countryCode = searchParams.get("countryCode") || "US";
+
+  const [genres, providers] = await Promise.all([
+    getTMDBGenres(),
+    getTMDBProviders(countryCode),
+  ]);
+
+  return NextResponse.json({ genres, providers });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,6 +164,17 @@
   --ring: oklch(0.62 0.21 350);
 }
 
+/* Suppress focus outline on Recharts for mouse clicks, keep for keyboard nav */
+.recharts-wrapper,
+.recharts-wrapper *,
+svg.recharts-surface,
+.recharts-surface,
+.recharts-layer {
+  outline: none !important;
+  outline-width: 0 !important;
+  box-shadow: none !important;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/components/company-detail-client.tsx
+++ b/components/company-detail-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useMemo, Suspense } from "react";
+import { useState, useMemo, Suspense, useEffect } from "react";
 import { TMDBMedia } from "@/lib/tmdb";
 import { TMDBCompanyDetails } from "@/lib/tmdb-actions";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
+import { CompanyDetailSkeleton } from "@/components/skeletons";
 import {
   ArrowLeft,
   Film,
@@ -14,8 +15,8 @@ import {
   ExternalLink,
   Info,
 } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import Card from "@/components/card";
 import QuickViewModal from "@/components/quick-view-modal";
 import AuthModal from "@/components/auth-modal";
@@ -29,18 +30,14 @@ import {
 } from "@/components/ui/select";
 
 interface CompanyDetailClientProps {
-  company: TMDBCompanyDetails;
-  movies: TMDBMedia[];
-  tvShows: TMDBMedia[];
+  id: string;
 }
 
 type MediaFilter = "all" | "movie" | "tv";
 type SortOption = "popularity" | "release_date" | "vote_average";
 
 export default function CompanyDetailClient({
-  company,
-  movies,
-  tvShows,
+  id,
 }: CompanyDetailClientProps) {
   const router = useRouter();
   const {
@@ -48,6 +45,26 @@ export default function CompanyDetailClient({
     isOpen: isAuthOpen,
     close: closeAuth,
   } = useAuthModalStore();
+
+  const [company, setCompany] = useState<TMDBCompanyDetails | null>(null);
+  const [movies, setMovies] = useState<TMDBMedia[]>([]);
+  const [tvShows, setTvShows] = useState<TMDBMedia[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/tmdb/company/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Not found");
+        return res.json();
+      })
+      .then((data) => {
+        setCompany(data.company);
+        setMovies(data.movies ?? []);
+        setTvShows(data.tvShows ?? []);
+      })
+      .catch(() => router.push("/"))
+      .finally(() => setIsLoading(false));
+  }, [id, router]);
 
   const [mediaFilter, setMediaFilter] = useState<MediaFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("popularity");
@@ -108,6 +125,9 @@ export default function CompanyDetailClient({
   // Count stats
   const movieCount = movies.length;
   const tvCount = tvShows.length;
+
+  if (isLoading) return <CompanyDetailSkeleton />;
+  if (!company) return null;
 
   return (
     <div className="min-h-screen bg-black pt-20 text-white">

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { TMDBMedia } from "@/lib/tmdb";
 import {
   getTrending,
@@ -21,25 +21,33 @@ import { FreeMode, Mousewheel } from "swiper/modules";
 import {
   CarouselSkeleton,
   ContinueWatchingCarouselSkeleton,
+  HeroSkeleton,
   Skeleton,
 } from "./skeletons";
 import Card from "./card";
 
-interface HomeClientProps {
-  initialHero: TMDBMedia[];
-  initialTrending: TMDBMedia[];
-  initialStreaming: TMDBMedia[];
-  initialGenre: TMDBMedia[];
-}
-
-export default function HomeClient({
-  initialHero,
-  initialTrending,
-  initialStreaming,
-  initialGenre,
-}: HomeClientProps) {
+export default function HomeClient() {
   const openAuth = useAuthModalStore((state) => state.open);
   const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+
+  const [heroItems, setHeroItems] = useState<TMDBMedia[]>([]);
+  const [trendingItems, setTrendingItems] = useState<TMDBMedia[]>([]);
+  const [streamingItems, setStreamingItems] = useState<TMDBMedia[]>([]);
+  const [categoryItems, setCategoryItems] = useState<TMDBMedia[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/tmdb/home")
+      .then((res) => res.json())
+      .then((data) => {
+        setHeroItems(data.hero ?? []);
+        setTrendingItems(data.trending ?? []);
+        setStreamingItems(data.streaming ?? []);
+        setCategoryItems(data.category ?? []);
+      })
+      .catch(console.error)
+      .finally(() => setIsLoading(false));
+  }, []);
 
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
@@ -56,12 +64,28 @@ export default function HomeClient({
     setQuickViewMedia(media);
   };
 
+  if (isLoading) {
+    return (
+      <div className="bg-background text-foreground flex min-h-svh flex-col overflow-x-hidden font-sans">
+        <HeroSkeleton />
+        <div className="bg-background relative z-20 flex flex-col gap-6 pb-20">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20">
+              <Skeleton className="h-6 w-44 rounded-md" />
+              <CarouselSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-background text-foreground flex min-h-svh flex-col overflow-x-hidden font-sans transition-colors duration-300">
       <main className="flex grow flex-col">
         {/* Fullscreen Hero Carousel */}
         <Hero
-          items={initialHero}
+          items={heroItems}
           onQuickView={handleQuickView}
           onAuthRequired={openAuth}
         />
@@ -173,7 +197,7 @@ export default function HomeClient({
           <div id="trending">
             <Section
               titleType="text"
-              defaultFetch={async () => initialTrending}
+              defaultFetch={async () => trendingItems}
               onTrendingChange={async (type) => getTrending(type)}
               onQuickView={handleQuickView}
               onAuthRequired={openAuth}
@@ -184,7 +208,7 @@ export default function HomeClient({
           <div id="originals">
             <Section
               titleType="dropdown-streaming"
-              defaultFetch={async () => initialStreaming}
+              defaultFetch={async () => streamingItems}
               onStreamingChange={async (key) => getStreamingOriginals(key)}
               onQuickView={handleQuickView}
               onAuthRequired={openAuth}
@@ -195,7 +219,7 @@ export default function HomeClient({
           <div id="category">
             <Section
               titleType="dropdown-genre"
-              defaultFetch={async () => initialGenre}
+              defaultFetch={async () => categoryItems}
               onGenreChange={async (name) => getByCategory(name)}
               onQuickView={handleQuickView}
               onAuthRequired={openAuth}

--- a/components/media-detail-client.tsx
+++ b/components/media-detail-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { useQuery, useMutation, useAction } from "convex/react";
@@ -8,6 +8,7 @@ import { api } from "@/convex/_generated/api";
 import { authClient } from "@/lib/auth-client";
 import { TMDBMedia } from "@/lib/tmdb";
 import { streamingProviderList } from "@/lib/streamingProviderList";
+import { MediaDetailSkeleton } from "@/components/skeletons";
 import {
   Star,
   Clock,
@@ -63,16 +64,7 @@ import { cn } from "@/lib/utils";
 
 interface MediaDetailClientProps {
   mediaType: "movie" | "tv";
-  initialData: {
-    details: MediaDetails;
-    credits?: { cast?: CastItem[]; crew?: CrewItem[] };
-    videos?: VideoItem[];
-    watchProviders?: Record<string, { flatrate?: ProviderItem[] }>;
-    logoPath?: string | null;
-    textlessPosterPath?: string | null;
-    recommendations?: TMDBMedia[];
-    regionalData?: (RegionalRelease | RegionalContentRating)[];
-  };
+  id: string;
 }
 
 // Map full country name string from profile/settings to ISO 2-letter code for TMDB dynamically
@@ -117,12 +109,51 @@ const getRegionLocale = (region: string): string => {
 
 export default function MediaDetailClient({
   mediaType,
-  initialData,
+  id,
 }: MediaDetailClientProps) {
   const router = useRouter();
-  const details = initialData.details;
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
+
+  // Fetched media data state
+  const [details, setDetails] = useState<MediaDetails | null>(null);
+  const [credits, setCredits] = useState<{ cast?: CastItem[]; crew?: CrewItem[] }>({});
+  const [videos, setVideos] = useState<VideoItem[]>([]);
+  const [watchProviders, setWatchProviders] = useState<Record<string, { flatrate?: ProviderItem[] }>>({});
+  const [logoPath, setLogoPath] = useState<string | null>(null);
+  const [textlessPosterPath, setTextlessPosterPath] = useState<string | null>(null);
+  const [recommendations, setRecommendations] = useState<TMDBMedia[]>([]);
+  const [regionalData, setRegionalData] = useState<(RegionalRelease | RegionalContentRating)[]>([]);
+  // Track current media so we can reset loading state during render when page details change
+  const [prevMediaId, setPrevMediaId] = useState(id);
+  const [prevMediaType, setPrevMediaType] = useState(mediaType);
+  const [isMediaLoading, setIsMediaLoading] = useState(true);
+
+  if (id !== prevMediaId || mediaType !== prevMediaType) {
+    setPrevMediaId(id);
+    setPrevMediaType(mediaType);
+    setIsMediaLoading(true);
+  }
+
+  useEffect(() => {
+    fetch(`/api/tmdb/media/${mediaType}/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Not found");
+        return res.json();
+      })
+      .then((data) => {
+        setDetails(data.details);
+        setCredits(data.credits ?? {});
+        setVideos(data.videos ?? []);
+        setWatchProviders(data.watchProviders ?? {});
+        setLogoPath(data.logoPath ?? null);
+        setTextlessPosterPath(data.textlessPosterPath ?? null);
+        setRecommendations(data.recommendations ?? []);
+        setRegionalData(data.regionalData ?? []);
+      })
+      .catch(() => router.push("/"))
+      .finally(() => setIsMediaLoading(false));
+  }, [mediaType, id, router]);
 
   // Global auth store & Scroll refs
   const openAuth = useAuthModalStore((state) => state.open);
@@ -149,15 +180,15 @@ export default function MediaDetailClient({
 
   const [seasonState, setSeasonState] = useQueryState("season");
   const season = seasonState ? parseInt(seasonState) || 1 : 1;
-  const setSeason = (s: number) => {
+  const setSeason = useCallback((s: number) => {
     setSeasonState(String(s));
-  };
+  }, [setSeasonState]);
 
   const [episodeState, setEpisodeState] = useQueryState("episode");
   const episode = episodeState ? parseInt(episodeState) || 1 : 1;
-  const setEpisode = (e: number) => {
+  const setEpisode = useCallback((e: number) => {
     setEpisodeState(String(e));
-  };
+  }, [setEpisodeState]);
   const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
   const [quickViewPersonId, setQuickViewPersonId] = useState<number | null>(
     null,
@@ -197,10 +228,7 @@ export default function MediaDetailClient({
           Promise.resolve().then(() => {
             setSelectedRegion(detectedRegion);
           });
-        } else if (
-          initialData.watchProviders &&
-          detectedRegion in initialData.watchProviders
-        ) {
+        } else if (detectedRegion in watchProviders) {
           Promise.resolve().then(() => {
             setSelectedRegion(detectedRegion);
           });
@@ -211,7 +239,7 @@ export default function MediaDetailClient({
         }
       }
     }
-  }, [initialData.watchProviders, convexProfile]);
+  }, [watchProviders, convexProfile]);
 
   // Parallax Scroll Effect
   useEffect(() => {
@@ -268,19 +296,21 @@ export default function MediaDetailClient({
         });
       }, 100);
 
-      getSeasonDetails(details.id, seasonNumber).then((data) => {
-        if (data) {
-          setActiveSeasonData(data as SeasonDetails);
-          // Re-scroll once actual episodes list loads and changes heights
-          setTimeout(() => {
-            seasonDetailsRef.current?.scrollIntoView({
-              behavior: "smooth",
-              block: "start",
-            });
-          }, 150);
-        }
-        setSeasonDetailsLoading(false);
-      });
+      if (details) {
+        getSeasonDetails(details.id, seasonNumber).then((data) => {
+          if (data) {
+            setActiveSeasonData(data as SeasonDetails);
+            // Re-scroll once actual episodes list loads and changes heights
+            setTimeout(() => {
+              seasonDetailsRef.current?.scrollIntoView({
+                behavior: "smooth",
+                block: "start",
+              });
+            }, 150);
+          }
+          setSeasonDetailsLoading(false);
+        });
+      }
     }
   };
 
@@ -288,8 +318,8 @@ export default function MediaDetailClient({
   const [watchlistLoading, setWatchlistLoading] = useState(false);
   const isWatchlisted = useQuery(
     api.watchlist.checkWatchlistItem,
-    isLoggedIn && initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    isLoggedIn && details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const addToWatchlist = useMutation(api.watchlist.addToWatchlist);
@@ -299,8 +329,8 @@ export default function MediaDetailClient({
   const [favoriteLoading, setFavoriteLoading] = useState(false);
   const isFavorited = useQuery(
     api.favorites.checkFavoriteItem,
-    isLoggedIn && initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    isLoggedIn && details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const addToFavorites = useMutation(api.favorites.addToFavorites);
@@ -309,14 +339,14 @@ export default function MediaDetailClient({
   // Convex rating mutations/queries
   const userRating = useQuery(
     api.ratings.getUserRating,
-    isLoggedIn && initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    isLoggedIn && details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const communityStats = useQuery(
     api.ratings.getCommunityRatingStats,
-    initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const deleteRating = useMutation(api.ratings.deleteRating);
@@ -324,8 +354,8 @@ export default function MediaDetailClient({
   // Convex diary history queries/mutations
   const watchHistory = useQuery(
     api.diary.getMediaWatchHistory,
-    isLoggedIn && initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    isLoggedIn && details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const [isLogModalOpen, setIsLogModalOpen] = useState(false);
@@ -352,8 +382,8 @@ export default function MediaDetailClient({
   // Convex watch progress query & mutation
   const watchProgress = useQuery(
     api.continueWatching.getProgressForMedia,
-    isLoggedIn && initialData.details
-      ? { mediaId: String(initialData.details.id), mediaType }
+    isLoggedIn && details
+      ? { mediaId: String(details.id), mediaType }
       : "skip",
   );
   const upsertWatchProgress = useMutation(api.continueWatching.upsertProgress);
@@ -415,6 +445,25 @@ export default function MediaDetailClient({
     return undefined;
   }, [mediaType, activeSeasonData, episode]);
 
+  // Convex exchange rates query and action
+  const exchangeRatesData = useQuery(api.exchangeRates.getRates);
+  const fetchRates = useAction(api.exchangeRates.fetchAndStoreRates);
+
+  useEffect(() => {
+    if (exchangeRatesData === undefined) return;
+
+    const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+    const isOutdated =
+      !exchangeRatesData ||
+      Date.now() - exchangeRatesData.updatedAt > ONE_WEEK_MS;
+
+    if (isOutdated) {
+      fetchRates().catch((err: unknown) => {
+        console.error("Failed to fetch and store exchange rates:", err);
+      });
+    }
+  }, [exchangeRatesData, fetchRates]);
+
   // Track and save watch progress
   useEffect(() => {
     if (isLoggedIn && activeTab === "watch" && details) {
@@ -440,24 +489,13 @@ export default function MediaDetailClient({
     upsertWatchProgress,
   ]);
 
-  // Convex exchange rates query and action
-  const exchangeRatesData = useQuery(api.exchangeRates.getRates);
-  const fetchRates = useAction(api.exchangeRates.fetchAndStoreRates);
+  // Show skeleton while media data is loading
+  if (isMediaLoading) {
+    return <MediaDetailSkeleton />;
+  }
 
-  useEffect(() => {
-    if (exchangeRatesData === undefined) return;
-
-    const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-    const isOutdated =
-      !exchangeRatesData ||
-      Date.now() - exchangeRatesData.updatedAt > ONE_WEEK_MS;
-
-    if (isOutdated) {
-      fetchRates().catch((err: unknown) => {
-        console.error("Failed to fetch and store exchange rates:", err);
-      });
-    }
-  }, [exchangeRatesData, fetchRates]);
+  // Guard against null details (shouldn't happen after loading, but satisfies TS)
+  if (!details) return null;
 
   const handleShareToChat = async (chatId: string, chatTitle: string) => {
     try {
@@ -481,22 +519,21 @@ export default function MediaDetailClient({
     }
   };
 
-  const cast = initialData.credits?.cast?.slice(0, 15) || [];
+  const cast = credits?.cast?.slice(0, 15) || [];
   const directors =
-    initialData.credits?.crew?.filter((c) => c.job === "Director") || [];
-  const creators = details.created_by || [];
-  const recommendations = initialData.recommendations || [];
+    credits?.crew?.filter((c) => c.job === "Director") || [];
+  const creators = details?.created_by || [];
   const providers =
-    initialData.watchProviders?.[selectedRegion]?.flatrate || [];
+    watchProviders?.[selectedRegion]?.flatrate || [];
 
   // YouTube trailer resolution
-  const trailerVideo = initialData.videos?.find(
+  const trailerVideo = videos?.find(
     (v: VideoItem) => v.type === "Trailer" && v.site === "YouTube",
   );
   const trailerKey =
     trailerVideo?.key ||
-    (initialData.videos?.[0]?.site === "YouTube"
-      ? initialData.videos[0].key
+    (videos?.[0]?.site === "YouTube"
+      ? videos[0].key
       : null);
 
   // Streaming server sources
@@ -513,8 +550,8 @@ export default function MediaDetailClient({
 
   // Find regional release date and content certification
   const regionalReleaseInfo = (() => {
-    if (mediaType !== "movie" || !initialData.regionalData) return null;
-    const movieReleaseData = initialData.regionalData as RegionalRelease[];
+    if (mediaType !== "movie" || !regionalData) return null;
+    const movieReleaseData = regionalData as RegionalRelease[];
     const regionRelease = movieReleaseData.find(
       (r) => r.iso_3166_1 === selectedRegion,
     );
@@ -533,8 +570,8 @@ export default function MediaDetailClient({
     if (mediaType === "movie") {
       return regionalReleaseInfo?.certification || null;
     } else {
-      if (!initialData.regionalData) return null;
-      const tvRatingsData = initialData.regionalData as RegionalContentRating[];
+      if (!regionalData) return null;
+      const tvRatingsData = regionalData as RegionalContentRating[];
       const regionRating = tvRatingsData.find(
         (r) => r.iso_3166_1 === selectedRegion,
       );
@@ -698,8 +735,8 @@ export default function MediaDetailClient({
     ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
     : "/logo/popcorn.png";
 
-  const mobileBackdropUrl = initialData.textlessPosterPath
-    ? `https://image.tmdb.org/t/p/w780${initialData.textlessPosterPath}`
+  const mobileBackdropUrl = textlessPosterPath
+    ? `https://image.tmdb.org/t/p/w780${textlessPosterPath}`
     : posterUrl;
 
   const duration = moment.duration(runtime, "minutes");
@@ -742,10 +779,10 @@ export default function MediaDetailClient({
           )}
 
           {/* Logo or Title */}
-          {initialData.logoPath && !logoError ? (
+          {logoPath && !logoError ? (
             <div className="relative mb-2 flex h-16 max-w-[85%] items-center sm:h-24 md:h-28">
               <img
-                src={`https://image.tmdb.org/t/p/w500${initialData.logoPath}`}
+                src={`https://image.tmdb.org/t/p/w500${logoPath}`}
                 alt={details?.title || details?.name}
                 className="h-full w-auto object-contain drop-shadow-[0_4px_8px_rgba(0,0,0,0.8)] filter"
                 onError={() => setLogoError(true)}
@@ -958,7 +995,7 @@ export default function MediaDetailClient({
                         )}
                       >
                         {c.logo_path && (
-                          <div className="flex aspect-[4/3] w-[100px] items-center justify-center rounded-lg bg-white/95 p-3 shadow-sm">
+                          <div className="flex aspect-4/3 w-25 items-center justify-center rounded-lg bg-white/95 p-3 shadow-sm">
                             <img
                               src={`https://image.tmdb.org/t/p/w92${c.logo_path}`}
                               alt={c.name}
@@ -1168,7 +1205,7 @@ export default function MediaDetailClient({
               Add to Custom List
             </DialogTitle>
           </DialogHeader>
-          <div className="max-h-[350px] space-y-4 overflow-y-auto py-4 pr-1">
+          <div className="max-h-87.5 space-y-4 overflow-y-auto py-4 pr-1">
             {customLists === undefined ? (
               <div className="flex justify-center py-6">
                 <Loader2 className="text-primary h-6 w-6 animate-spin" />

--- a/components/person-detail-client.tsx
+++ b/components/person-detail-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo, Suspense } from "react";
+import { useState, useMemo, Suspense, useEffect } from "react";
 import { TMDBMedia, cleanMediaData, TMDBRawItem } from "@/lib/tmdb";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
+import { PersonDetailSkeleton } from "@/components/skeletons";
 import {
   ArrowLeft,
   Film,
@@ -13,7 +14,6 @@ import {
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import Card from "@/components/card";
@@ -53,8 +53,7 @@ interface PersonCredits {
 }
 
 interface PersonDetailClientProps {
-  person: TMDBPerson;
-  credits: PersonCredits;
+  id: string;
 }
 
 type MediaFilter = "all" | "movie" | "tv";
@@ -62,8 +61,7 @@ type RoleFilter = "all" | "cast" | "crew";
 type SortOption = "popularity" | "release_date" | "vote_average";
 
 export default function PersonDetailClient({
-  person,
-  credits,
+  id,
 }: PersonDetailClientProps) {
   const router = useRouter();
   const {
@@ -71,7 +69,24 @@ export default function PersonDetailClient({
     isOpen: isAuthOpen,
     close: closeAuth,
   } = useAuthModalStore();
-  // No-op
+
+  const [person, setPerson] = useState<TMDBPerson | null>(null);
+  const [credits, setCredits] = useState<PersonCredits>({ cast: [], crew: [] });
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/tmdb/person/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Not found");
+        return res.json();
+      })
+      .then((data) => {
+        setPerson(data.person);
+        setCredits(data.credits ?? { cast: [], crew: [] });
+      })
+      .catch(() => router.push("/"))
+      .finally(() => setIsLoading(false));
+  }, [id, router]);
 
   const [isBioExpanded, setIsBioExpanded] = useState(false);
   const [mediaFilter, setMediaFilter] = useState<MediaFilter>("all");
@@ -170,20 +185,23 @@ export default function PersonDetailClient({
     return result;
   }, [mergedCredits, mediaFilter, roleFilter, sortBy]);
 
-  const profileUrl = person.profile_path
-    ? `https://image.tmdb.org/t/p/h632${person.profile_path}`
-    : "/logo/popcorn.png";
-
   // Age calculation
   const age = useMemo(() => {
-    if (!person.birthday) return null;
+    if (!person?.birthday) return null;
     const birth = moment(person.birthday);
     if (person.deathday) {
       const death = moment(person.deathday);
       return `${death.diff(birth, "years")} (Deceased)`;
     }
     return moment().diff(birth, "years");
-  }, [person.birthday, person.deathday]);
+  }, [person]);
+
+  if (isLoading) return <PersonDetailSkeleton />;
+  if (!person) return null;
+
+  const profileUrl = person.profile_path
+    ? `https://image.tmdb.org/t/p/h632${person.profile_path}`
+    : "/logo/popcorn.png";
 
   return (
     <main className="bg-background text-foreground min-h-svh pt-24 pb-16 transition-colors duration-300">
@@ -202,7 +220,7 @@ export default function PersonDetailClient({
         <div className="grid grid-cols-1 gap-10 md:grid-cols-[280px_1fr] lg:gap-16">
           {/* Left Column: Photo & Details */}
           <div className="flex flex-col items-center text-center md:items-start md:text-left">
-            <div className="aspect-2/3 w-full max-w-[280px] overflow-hidden rounded-2xl border border-zinc-800/80 bg-zinc-900 shadow-2xl">
+            <div className="aspect-2/3 w-full max-w-70 overflow-hidden rounded-2xl border border-zinc-800/80 bg-zinc-900 shadow-2xl">
               <img
                 src={profileUrl}
                 alt={person.name}

--- a/components/search-client.tsx
+++ b/components/search-client.tsx
@@ -9,6 +9,7 @@ import {
   Suspense,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { searchMedia, discoverMedia } from "@/lib/tmdb-actions";
 import { TMDBMedia } from "@/lib/tmdb";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
@@ -54,7 +55,6 @@ import { SearchType, SearchUserResult } from "./search/types";
 import { ResultsSection } from "./search/results-section";
 
 interface SearchClientProps {
-  initialResults: TMDBMedia[];
   initialQuery: string;
   initialType: SearchType;
   initialGenre?: string;
@@ -70,13 +70,6 @@ interface SearchClientProps {
   initialRatingMax?: string;
   initialLanguage?: string;
   initialKeywords?: string;
-  genres: { id: number; name: string; types?: ("movie" | "tv")[] }[];
-  providers: {
-    provider_id: number;
-    provider_name: string;
-    logo_path: string;
-  }[];
-  userCountryCode?: string;
 }
 
 const TYPE_FILTERS: {
@@ -104,7 +97,6 @@ const LANGUAGES = [
 ];
 
 export default function SearchClient({
-  initialResults,
   initialQuery,
   initialType,
   initialGenre = "",
@@ -120,9 +112,6 @@ export default function SearchClient({
   initialRatingMax = "",
   initialLanguage = "",
   initialKeywords = "",
-  genres = [],
-  providers = [],
-  userCountryCode = "US",
 }: SearchClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -134,8 +123,41 @@ export default function SearchClient({
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
 
-  const [searchMode, setSearchMode] = useState<"search" | "discover">(
-    initialGenre ||
+  // Detect country from browser locale for provider filtering
+  const [userCountryCode, setUserCountryCode] = useState(() => {
+    let detectedCountry = "US";
+    if (typeof window !== "undefined" && typeof navigator !== "undefined") {
+      const locale =
+        navigator.language || (navigator.languages && navigator.languages[0]);
+      if (locale) {
+        const parts = locale.split("-");
+        detectedCountry = parts[1]
+          ? parts[1].toUpperCase()
+          : parts[0].toUpperCase();
+      }
+    }
+    return detectedCountry;
+  });
+  const [genres, setGenres] = useState<
+    { id: number; name: string; types?: ("movie" | "tv")[] }[]
+  >([]);
+  const [providers, setProviders] = useState<
+    { provider_id: number; provider_name: string; logo_path: string }[]
+  >([]);
+
+  useEffect(() => {
+    fetch(`/api/tmdb/search/meta?countryCode=${userCountryCode}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setGenres(data.genres ?? []);
+        setProviders(data.providers ?? []);
+      })
+      .catch(console.error);
+  }, [userCountryCode]);
+
+  const [searchModeState, setSearchModeState] = useQueryState("mode", {
+    defaultValue:
+      initialGenre ||
       initialStartDate ||
       initialEndDate ||
       initialProviderId ||
@@ -148,35 +170,59 @@ export default function SearchClient({
       initialRatingMax ||
       initialLanguage ||
       initialKeywords
-      ? "discover"
-      : "search",
-  );
+        ? "discover"
+        : "search",
+  });
+  const searchMode = (
+    searchModeState === "discover" ? "discover" : "search"
+  ) as "search" | "discover";
+  const setSearchMode = (mode: "search" | "discover") => {
+    setSearchModeState(mode);
+  };
 
-  const [query, setQuery] = useState(initialQuery);
+  const [query, setQuery] = useQueryState("q", { defaultValue: "" });
   const [inputValue, setInputValue] = useState(initialQuery);
-  const [activeType, setActiveType] = useState<SearchType>(initialType);
-  const [results, setResults] = useState<TMDBMedia[]>(initialResults);
+  const [activeType, setActiveType] = useQueryState("type", {
+    defaultValue: "movie",
+  });
+  const [results, setResults] = useState<TMDBMedia[]>([]);
   const [isPending, startTransition] = useTransition();
   const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
 
-  // Advanced Filters State
-  const [genre, setGenre] = useState(initialGenre); // holds genre ID string
-  const [startDate, setStartDate] = useState(initialStartDate);
-  const [endDate, setEndDate] = useState(initialEndDate);
-  const [providerId, setProviderId] = useState(initialProviderId); // holds provider ID string
-  const [minRuntime, setMinRuntime] = useState(initialMinRuntime);
-  const [maxRuntime, setMaxRuntime] = useState(initialMaxRuntime);
-  const [actor, setActor] = useState(initialActor);
-  const [crew, setCrew] = useState(initialCrew);
-  const [company, setCompany] = useState(initialCompany);
-  const [ratingMin, setRatingMin] = useState(initialRatingMin);
-  const [ratingMax, setRatingMax] = useState(initialRatingMax);
-  const [language, setLanguage] = useState(initialLanguage);
-  const [keywords, setKeywords] = useState(initialKeywords);
+  // Advanced Filters State using nuqs useQueryState
+  const [genre, setGenre] = useQueryState("genre", { defaultValue: "" });
+  const [startDate, setStartDate] = useQueryState("startDate", {
+    defaultValue: "",
+  });
+  const [endDate, setEndDate] = useQueryState("endDate", { defaultValue: "" });
+  const [providerId, setProviderId] = useQueryState("providerId", {
+    defaultValue: "",
+  });
+  const [minRuntime, setMinRuntime] = useQueryState("minRuntime", {
+    defaultValue: "",
+  });
+  const [maxRuntime, setMaxRuntime] = useQueryState("maxRuntime", {
+    defaultValue: "",
+  });
+  const [actor, setActor] = useQueryState("actor", { defaultValue: "" });
+  const [crew, setCrew] = useQueryState("crew", { defaultValue: "" });
+  const [company, setCompany] = useQueryState("company", { defaultValue: "" });
+  const [ratingMin, setRatingMin] = useQueryState("ratingMin", {
+    defaultValue: "",
+  });
+  const [ratingMax, setRatingMax] = useQueryState("ratingMax", {
+    defaultValue: "",
+  });
+  const [language, setLanguage] = useQueryState("language", {
+    defaultValue: "",
+  });
+  const [keywords, setKeywords] = useQueryState("keywords", {
+    defaultValue: "",
+  });
 
   // Infinite Scroll State
   const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(initialResults.length >= 20);
+  const [hasMore, setHasMore] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
 
@@ -199,7 +245,6 @@ export default function SearchClient({
     if (actorDebounceRef.current) clearTimeout(actorDebounceRef.current);
     actorDebounceRef.current = setTimeout(() => {
       setActor(val);
-      performSearch({ actor: val });
     }, 500);
   };
 
@@ -209,7 +254,6 @@ export default function SearchClient({
     if (crewDebounceRef.current) clearTimeout(crewDebounceRef.current);
     crewDebounceRef.current = setTimeout(() => {
       setCrew(val);
-      performSearch({ crew: val });
     }, 500);
   };
 
@@ -219,7 +263,6 @@ export default function SearchClient({
     if (companyDebounceRef.current) clearTimeout(companyDebounceRef.current);
     companyDebounceRef.current = setTimeout(() => {
       setCompany(val);
-      performSearch({ company: val });
     }, 500);
   };
 
@@ -229,7 +272,6 @@ export default function SearchClient({
     if (keywordsDebounceRef.current) clearTimeout(keywordsDebounceRef.current);
     keywordsDebounceRef.current = setTimeout(() => {
       setKeywords(val);
-      performSearch({ keywords: val });
     }, 500);
   };
 
@@ -239,14 +281,6 @@ export default function SearchClient({
       const maxVal = values[1];
       setRatingMin(String(minVal));
       setRatingMax(String(maxVal));
-
-      if (ratingDebounceRef.current) clearTimeout(ratingDebounceRef.current);
-      ratingDebounceRef.current = setTimeout(() => {
-        performSearch({
-          ratingMin: String(minVal),
-          ratingMax: String(maxVal),
-        });
-      }, 400);
     }
   };
 
@@ -298,158 +332,65 @@ export default function SearchClient({
     return found ? String(found.provider_id) : "";
   };
 
-  // Push URL update and fetch results
-  const performSearch = useCallback(
-    (paramsObj: {
-      q?: string;
-      type?: SearchType;
-      genre?: string;
-      startDate?: string;
-      endDate?: string;
-      providerId?: string;
-      minRuntime?: string;
-      maxRuntime?: string;
-      actor?: string;
-      crew?: string;
-      company?: string;
-      ratingMin?: string;
-      ratingMax?: string;
-      language?: string;
-      keywords?: string;
-    }) => {
-      const params = new URLSearchParams(searchParams.toString());
+  // Push URL update and fetch results triggered by state changes
+  useEffect(() => {
+    if (activeType === "users") return;
 
-      const newQuery = paramsObj.q !== undefined ? paramsObj.q : query;
-      const newType =
-        paramsObj.type !== undefined ? paramsObj.type : activeType;
-      const newGenre = paramsObj.genre !== undefined ? paramsObj.genre : genre;
-      const newStartDate =
-        paramsObj.startDate !== undefined ? paramsObj.startDate : startDate;
-      const newEndDate =
-        paramsObj.endDate !== undefined ? paramsObj.endDate : endDate;
-      const newProviderId =
-        paramsObj.providerId !== undefined ? paramsObj.providerId : providerId;
-      const newMinRuntime =
-        paramsObj.minRuntime !== undefined ? paramsObj.minRuntime : minRuntime;
-      const newMaxRuntime =
-        paramsObj.maxRuntime !== undefined ? paramsObj.maxRuntime : maxRuntime;
-      const newActor = paramsObj.actor !== undefined ? paramsObj.actor : actor;
-      const newCrew = paramsObj.crew !== undefined ? paramsObj.crew : crew;
-      const newCompany =
-        paramsObj.company !== undefined ? paramsObj.company : company;
-      const newRatingMin =
-        paramsObj.ratingMin !== undefined ? paramsObj.ratingMin : ratingMin;
-      const newRatingMax =
-        paramsObj.ratingMax !== undefined ? paramsObj.ratingMax : ratingMax;
-      const newLanguage =
-        paramsObj.language !== undefined ? paramsObj.language : language;
-      const newKeywords =
-        paramsObj.keywords !== undefined ? paramsObj.keywords : keywords;
-
-      if (newQuery) params.set("q", newQuery);
-      else params.delete("q");
-
-      if (newType !== "all") params.set("type", newType);
-      else params.delete("type");
-
-      if (newGenre) params.set("genre", newGenre);
-      else params.delete("genre");
-
-      if (newStartDate) params.set("startDate", newStartDate);
-      else params.delete("startDate");
-
-      if (newEndDate) params.set("endDate", newEndDate);
-      else params.delete("endDate");
-
-      if (newProviderId) params.set("providerId", newProviderId);
-      else params.delete("providerId");
-
-      if (newMinRuntime) params.set("minRuntime", newMinRuntime);
-      else params.delete("minRuntime");
-
-      if (newMaxRuntime) params.set("maxRuntime", newMaxRuntime);
-      else params.delete("maxRuntime");
-
-      if (newActor) params.set("actor", newActor);
-      else params.delete("actor");
-
-      if (newCrew) params.set("crew", newCrew);
-      else params.delete("crew");
-
-      if (newCompany) params.set("company", newCompany);
-      else params.delete("company");
-
-      if (newRatingMin) params.set("ratingMin", newRatingMin);
-      else params.delete("ratingMin");
-
-      if (newRatingMax) params.set("ratingMax", newRatingMax);
-      else params.delete("ratingMax");
-
-      if (newLanguage) params.set("language", newLanguage);
-      else params.delete("language");
-
-      if (newKeywords) params.set("keywords", newKeywords);
-      else params.delete("keywords");
-
-      router.push(`/search?${params.toString()}`, { scroll: false });
-
-      if (newType !== "users") {
-        startTransition(async () => {
-          setPage(1);
-          setHasMore(true);
-          let data: TMDBMedia[] = [];
-          if (newQuery) {
-            data = await searchMedia(newQuery, newType, 1);
-          } else {
-            data = await discoverMedia(
-              {
-                genre: newGenre,
-                startDate: newStartDate,
-                endDate: newEndDate,
-                providerId: newProviderId,
-                minRuntime: newMinRuntime,
-                maxRuntime: newMaxRuntime,
-                actor: newActor,
-                crew: newCrew,
-                company: newCompany,
-                ratingMin: newRatingMin,
-                ratingMax: newRatingMax,
-                language: newLanguage,
-                keywords: newKeywords,
-              },
-              newType,
-              1,
-              userCountryCode,
-            );
-          }
-          setResults(data);
-          if (data.length < 20) {
-            setHasMore(false);
-          }
-        });
+    startTransition(async () => {
+      setPage(1);
+      setHasMore(true);
+      let data: TMDBMedia[] = [];
+      if (query) {
+        data = await searchMedia(
+          query,
+          activeType as "all" | "movie" | "tv",
+          1,
+        );
+      } else {
+        data = await discoverMedia(
+          {
+            genre: genre || "",
+            startDate: startDate || "",
+            endDate: endDate || "",
+            providerId: providerId || "",
+            minRuntime: minRuntime || "",
+            maxRuntime: maxRuntime || "",
+            actor: actor || "",
+            crew: crew || "",
+            company: company || "",
+            ratingMin: ratingMin || "",
+            ratingMax: ratingMax || "",
+            language: language || "",
+            keywords: keywords || "",
+          },
+          activeType as "all" | "movie" | "tv",
+          1,
+          userCountryCode,
+        );
       }
-    },
-    [
-      router,
-      searchParams,
-      query,
-      activeType,
-      genre,
-      startDate,
-      endDate,
-      providerId,
-      minRuntime,
-      maxRuntime,
-      actor,
-      crew,
-      company,
-      ratingMin,
-      ratingMax,
-      language,
-      keywords,
-      userCountryCode,
-    ],
-  );
+      setResults(data);
+      if (data.length < 20) {
+        setHasMore(false);
+      }
+    });
+  }, [
+    query,
+    activeType,
+    genre,
+    startDate,
+    endDate,
+    providerId,
+    minRuntime,
+    maxRuntime,
+    actor,
+    crew,
+    company,
+    ratingMin,
+    ratingMax,
+    language,
+    keywords,
+    userCountryCode,
+  ]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
@@ -457,7 +398,6 @@ export default function SearchClient({
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       setQuery(val);
-      performSearch({ q: val });
     }, 400);
   };
 
@@ -484,7 +424,6 @@ export default function SearchClient({
     setPage(1);
     setHasMore(false);
     setResults([]);
-    router.push("/search", { scroll: false });
   };
 
   const handleTypeChange = (type: SearchType) => {
@@ -502,8 +441,6 @@ export default function SearchClient({
         setGenre("");
       }
     }
-
-    performSearch({ type, genre: nextGenre });
   };
 
   const handleSearchModeChange = (mode: "search" | "discover") => {
@@ -529,49 +466,13 @@ export default function SearchClient({
       setCrewInput("");
       setCompanyInput("");
       setKeywordsInput("");
-
-      performSearch({
-        q: query,
-        genre: "",
-        startDate: "",
-        endDate: "",
-        providerId: "",
-        minRuntime: "",
-        maxRuntime: "",
-        actor: "",
-        crew: "",
-        company: "",
-        ratingMin: "",
-        ratingMax: "",
-        language: "",
-        keywords: "",
-      });
     } else {
       setInputValue("");
       setQuery("");
 
-      const nextType = activeType === "users" ? "movie" : activeType;
       if (activeType === "users") {
         setActiveType("movie");
       }
-
-      performSearch({
-        q: "",
-        type: nextType,
-        genre: genre,
-        startDate: startDate,
-        endDate: endDate,
-        providerId: providerId,
-        minRuntime: minRuntime,
-        maxRuntime: maxRuntime,
-        actor: actor,
-        crew: crew,
-        company: company,
-        ratingMin: ratingMin,
-        ratingMax: ratingMax,
-        language: language,
-        keywords: keywords,
-      });
     }
   };
 
@@ -630,7 +531,6 @@ export default function SearchClient({
   const handleStartDateChange = (date: Date | undefined) => {
     if (!date) {
       setStartDate("");
-      performSearch({ startDate: "" });
       return;
     }
     const year = date.getFullYear();
@@ -638,13 +538,11 @@ export default function SearchClient({
     const day = String(date.getDate()).padStart(2, "0");
     const formatted = `${year}-${month}-${day}`;
     setStartDate(formatted);
-    performSearch({ startDate: formatted });
   };
 
   const handleEndDateChange = (date: Date | undefined) => {
     if (!date) {
       setEndDate("");
-      performSearch({ endDate: "" });
       return;
     }
     const year = date.getFullYear();
@@ -652,7 +550,6 @@ export default function SearchClient({
     const day = String(date.getDate()).padStart(2, "0");
     const formatted = `${year}-${month}-${day}`;
     setEndDate(formatted);
-    performSearch({ endDate: formatted });
   };
 
   const handleRuntimeChange = (values: number | readonly number[]) => {
@@ -661,14 +558,6 @@ export default function SearchClient({
       const maxVal = values[1];
       setMinRuntime(String(minVal));
       setMaxRuntime(String(maxVal));
-
-      if (runtimeDebounceRef.current) clearTimeout(runtimeDebounceRef.current);
-      runtimeDebounceRef.current = setTimeout(() => {
-        performSearch({
-          minRuntime: String(minVal),
-          maxRuntime: String(maxVal),
-        });
-      }, 400);
     }
   };
 
@@ -693,21 +582,6 @@ export default function SearchClient({
     setKeywordsInput("");
     setPage(1);
     setHasMore(true);
-    performSearch({
-      genre: "",
-      startDate: "",
-      endDate: "",
-      providerId: "",
-      minRuntime: "",
-      maxRuntime: "",
-      actor: "",
-      crew: "",
-      company: "",
-      ratingMin: "",
-      ratingMax: "",
-      language: "",
-      keywords: "",
-    });
   };
 
   // Helper to format date display
@@ -730,25 +604,28 @@ export default function SearchClient({
 
     try {
       let nextResults: TMDBMedia[] = [];
-      const typeParam = activeType !== "users" ? activeType : "all";
+      const typeParam =
+        activeType !== "users" && activeType
+          ? (activeType as "all" | "movie" | "tv")
+          : "all";
       if (query) {
         nextResults = await searchMedia(query, typeParam, nextPage);
       } else if (searchMode === "discover") {
         nextResults = await discoverMedia(
           {
-            genre,
-            startDate,
-            endDate,
-            providerId,
-            minRuntime,
-            maxRuntime,
-            actor,
-            crew,
-            company,
-            ratingMin,
-            ratingMax,
-            language,
-            keywords,
+            genre: genre || "",
+            startDate: startDate || "",
+            endDate: endDate || "",
+            providerId: providerId || "",
+            minRuntime: minRuntime || "",
+            maxRuntime: maxRuntime || "",
+            actor: actor || "",
+            crew: crew || "",
+            company: company || "",
+            ratingMin: ratingMin || "",
+            ratingMax: ratingMax || "",
+            language: language || "",
+            keywords: keywords || "",
           },
           typeParam,
           nextPage,
@@ -832,12 +709,11 @@ export default function SearchClient({
             Genre
           </span>
           <Combobox
-            value={getGenreName(genre)}
+            value={getGenreName(genre || "")}
             onValueChange={(val) => {
               const name = (val as string) || "";
               const id = getGenreIdByName(name);
               setGenre(id);
-              performSearch({ genre: id });
             }}
             items={filteredGenres.map((g) => g.name)}
           >
@@ -871,12 +747,11 @@ export default function SearchClient({
             Streaming Service ({userCountryCode})
           </span>
           <Combobox
-            value={getProviderName(providerId)}
+            value={getProviderName(providerId || "")}
             onValueChange={(val) => {
               const name = (val as string) || "";
               const id = getProviderIdByName(name);
               setProviderId(id);
-              performSearch({ providerId: id });
             }}
             items={providers.map((p) => p.provider_name)}
           >
@@ -979,14 +854,14 @@ export default function SearchClient({
           </span>
           <Combobox
             value={
-              LANGUAGES.find((l) => l.code === language)?.name || "Any Language"
+              LANGUAGES.find((l) => l.code === (language || ""))?.name ||
+              "Any Language"
             }
             onValueChange={(val) => {
               const name = (val as string) || "";
               const lang = LANGUAGES.find((l) => l.name === name);
               const code = lang ? lang.code : "";
               setLanguage(code);
-              performSearch({ language: code });
             }}
             items={LANGUAGES.map((l) => l.name)}
           >
@@ -1272,7 +1147,7 @@ export default function SearchClient({
                       </SheetTrigger>
                       <SheetContent
                         side="right"
-                        className="no-scrollbar flex w-[300px] flex-col gap-6 overflow-y-auto rounded-l-3xl border-l border-zinc-800 bg-zinc-950/95 p-6 text-white backdrop-blur-xl"
+                        className="no-scrollbar flex w-75 flex-col gap-6 overflow-y-auto rounded-l-3xl border-l border-zinc-800 bg-zinc-950/95 p-6 text-white backdrop-blur-xl"
                       >
                         <SheetHeader className="mb-6 border-b border-zinc-800/80 p-0 pb-3">
                           <SheetTitle className="flex items-center gap-2 text-sm font-bold text-white">
@@ -1300,8 +1175,8 @@ export default function SearchClient({
 
             {/* Results area */}
             <ResultsSection
-              activeType={activeType}
-              query={query}
+              activeType={(activeType || "movie") as SearchType}
+              query={query || ""}
               hasQuery={searchMode === "discover" || hasQuery || hasFilters}
               isUsersLoading={isUsersLoading}
               isPending={isPending}

--- a/components/skeletons.tsx
+++ b/components/skeletons.tsx
@@ -22,36 +22,50 @@ export function Skeleton({ className }: SkeletonProps) {
 // Fullscreen Hero Skeleton
 export function HeroSkeleton() {
   return (
-    <div className="relative flex h-[90svh] w-full items-end overflow-hidden bg-zinc-950 px-6 pb-12 sm:h-svh sm:px-16">
+    <div className="relative flex h-[90svh] w-full items-end overflow-hidden bg-zinc-950 px-6 pb-16 sm:h-svh sm:px-16 sm:pb-24 md:px-20">
       {/* Backdrop mockup */}
-      <div className="absolute inset-0 z-10 bg-linear-to-t from-zinc-950 via-zinc-950/40 to-transparent" />
       <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
+      <div className="absolute inset-0 z-10 bg-linear-to-t from-zinc-950 via-zinc-950/45 to-black/10" />
+      <div className="absolute inset-0 z-10 hidden bg-linear-to-r from-zinc-950/80 via-transparent to-transparent md:block" />
 
       {/* Hero content */}
-      <div className="relative z-20 flex w-full max-w-4xl flex-col gap-6 sm:flex-row sm:items-end sm:gap-10">
-        {/* Poster Skeleton */}
-        <Skeleton className="hidden h-72 w-48 shrink-0 rounded-xl shadow-2xl shadow-black/80 sm:block" />
+      <div className="relative z-20 flex w-full max-w-5xl flex-col items-end gap-8 md:flex-row md:gap-10">
+        {/* Poster Skeleton (hidden on mobile, visible on desktop) */}
+        <div className="hidden h-76 w-52 shrink-0 rounded-2xl border border-zinc-700/30 shadow-2xl shadow-black/85 lg:block">
+          <Skeleton className="h-full w-full rounded-2xl" />
+        </div>
 
         {/* Text Skeletons */}
-        <div className="flex flex-1 flex-col gap-3">
-          {/* Badge & Rating Skeletons */}
-          <div className="flex items-center gap-3">
+        <div className="flex w-full flex-1 flex-col items-start gap-4 text-left">
+          {/* Genre Badges */}
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-6 w-16 rounded-xl" />
+            <Skeleton className="h-6 w-20 rounded-xl" />
+            <Skeleton className="h-6 w-16 rounded-xl" />
+          </div>
+
+          {/* Title Placeholder */}
+          <Skeleton className="h-12 w-3/4 rounded-lg sm:h-16 md:h-20" />
+
+          {/* Meta rows (TV/Movie type, Rating, Year) */}
+          <div className="flex flex-wrap items-center gap-3">
             <Skeleton className="h-6 w-20 rounded-full" />
             <Skeleton className="h-6 w-14 rounded-full" />
-            <Skeleton className="h-6 w-12 rounded-full" />
+            <Skeleton className="h-5 w-12 rounded" />
           </div>
-          {/* Title */}
-          <Skeleton className="h-12 w-3/4 rounded-lg sm:h-16" />
-          {/* Overview */}
-          <div className="mt-2 flex flex-col gap-2">
+
+          {/* Overview text lines */}
+          <div className="mt-1 flex w-full max-w-2xl flex-col gap-2">
             <Skeleton className="h-4 w-full rounded" />
             <Skeleton className="h-4 w-11/12 rounded" />
             <Skeleton className="h-4 w-4/5 rounded" />
           </div>
-          {/* Action buttons */}
-          <div className="mt-6 flex gap-4">
+
+          {/* Action buttons (View Details, Watchlist, Favorite) */}
+          <div className="mt-6 flex items-center gap-4">
             <Skeleton className="h-12 w-36 rounded-full" />
-            <Skeleton className="h-12 w-36 rounded-full" />
+            <Skeleton className="h-12 w-12 rounded-full sm:w-36" />
+            <Skeleton className="h-12 w-12 rounded-full sm:w-36" />
           </div>
         </div>
       </div>
@@ -145,6 +159,242 @@ export function ContinueWatchingCarouselSkeleton() {
           </SwiperSlide>
         ))}
       </Swiper>
+    </div>
+  );
+}
+
+// Media Detail Page Skeleton (movie / tv)
+export function MediaDetailSkeleton() {
+  return (
+    <div className="bg-background text-foreground min-h-svh">
+      {/* Backdrop area mimicking MediaHero */}
+      <div className="relative h-[65svh] w-full overflow-hidden">
+        <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
+        <div className="absolute inset-0 z-10 bg-linear-to-t from-zinc-950 via-zinc-950/45 to-transparent" />
+      </div>
+
+      {/* Content Container shifted upwards to overlap backdrop */}
+      <div className="relative z-20 mx-auto -mt-24 flex max-w-7xl flex-col items-start gap-8 px-6 sm:-mt-36 sm:px-12 md:-mt-44 md:flex-row md:gap-12 md:px-20">
+        {/* Large Poster Sidebar */}
+        <div className="hidden w-64 shrink-0 overflow-hidden rounded-2xl border border-zinc-800/40 bg-zinc-900 md:block">
+          <Skeleton className="aspect-2/3 w-full rounded-none" />
+        </div>
+
+        {/* Details Header Details */}
+        <div className="flex w-full flex-1 flex-col items-start gap-4 text-left">
+          {/* Genre Badges */}
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-16 rounded-xl" />
+            <Skeleton className="h-6 w-20 rounded-xl" />
+            <Skeleton className="h-6 w-16 rounded-xl" />
+          </div>
+
+          {/* Title or Logo Placeholder */}
+          <Skeleton className="h-12 w-3/4 rounded-lg sm:h-16 md:h-20" />
+
+          {/* Tagline */}
+          <Skeleton className="h-5 w-1/2 rounded" />
+
+          {/* Meta rows (Rating, Year, Duration) */}
+          <div className="flex w-full flex-wrap items-center gap-3">
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-6 w-14 rounded-full" />
+            <Skeleton className="h-6 w-12 rounded-full" />
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+
+          {/* Action buttons / quick stats */}
+          <div className="mt-2 flex w-full flex-wrap gap-4">
+            <Skeleton className="h-12 w-36 rounded-full" />
+            <Skeleton className="h-12 w-36 rounded-full" />
+          </div>
+        </div>
+      </div>
+
+      {/* Below-fold content */}
+      <div className="mx-auto mt-10 max-w-7xl space-y-10 px-6 py-10 sm:px-12 md:px-20">
+        {/* Cast row */}
+        <div className="space-y-4">
+          <Skeleton className="h-7 w-32 rounded" />
+          <div className="flex gap-4 overflow-hidden">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex shrink-0 flex-col items-center gap-2"
+              >
+                <Skeleton className="h-20 w-20 rounded-full" />
+                <Skeleton className="h-3.5 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Person Detail Page Skeleton
+export function PersonDetailSkeleton() {
+  return (
+    <div className="bg-background text-foreground min-h-svh pt-24 pb-16">
+      <div className="mx-auto max-w-7xl px-6 sm:px-10 md:px-16">
+        {/* Back Link Placeholder */}
+        <div className="mb-8 flex items-center gap-2">
+          <Skeleton className="h-4 w-12 rounded" />
+        </div>
+
+        {/* Profile Header Grid */}
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-[280px_1fr] lg:gap-16">
+          {/* Left Column: Photo & Details */}
+          <div className="flex flex-col items-center text-center md:items-start md:text-left">
+            <div className="aspect-2/3 w-full max-w-70 overflow-hidden rounded-2xl border border-zinc-800/80 bg-zinc-900 shadow-2xl">
+              <Skeleton className="h-full w-full rounded-none" />
+            </div>
+
+            <div className="mt-8 w-full space-y-4">
+              <Skeleton className="h-6 w-32 rounded" />
+              <div className="space-y-2">
+                <Skeleton className="h-3 w-16 rounded" />
+                <Skeleton className="h-4.5 w-24 rounded" />
+              </div>
+              <div className="space-y-2">
+                <Skeleton className="h-3 w-16 rounded" />
+                <Skeleton className="h-4.5 w-32 rounded" />
+              </div>
+              <div className="space-y-2">
+                <Skeleton className="h-3 w-24 rounded" />
+                <Skeleton className="h-4.5 w-40 rounded" />
+              </div>
+            </div>
+          </div>
+
+          {/* Right Column: Bio & Filmography */}
+          <div className="flex w-full flex-col gap-8">
+            <div>
+              {/* Name */}
+              <Skeleton className="h-10 w-2/3 rounded-lg sm:h-12" />
+
+              {/* Biography */}
+              <div className="mt-6 space-y-3">
+                <Skeleton className="h-6 w-24 rounded" />
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-full rounded" />
+                  <Skeleton className="h-4 w-full rounded" />
+                  <Skeleton className="h-4 w-11/12 rounded" />
+                  <Skeleton className="h-4 w-4/5 rounded" />
+                </div>
+              </div>
+            </div>
+
+            {/* Filmography Section */}
+            <div>
+              {/* Title & Filter bar header */}
+              <div className="border-zinc-850 mb-6 flex flex-col gap-4 border-b pb-4 lg:flex-row lg:items-center lg:justify-between">
+                <Skeleton className="h-8 w-44 rounded-lg" />
+                <div className="flex gap-2">
+                  <Skeleton className="h-9 w-32 rounded-xl" />
+                  <Skeleton className="h-9 w-32 rounded-xl" />
+                  <Skeleton className="h-9 w-24 rounded-xl" />
+                </div>
+              </div>
+
+              {/* Grid of movies/tv shows */}
+              <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                {Array.from({ length: 10 }).map((_, i) => (
+                  <div key={i} className="flex flex-col gap-2">
+                    <CardSkeleton />
+                    <Skeleton className="mx-auto h-3 w-16 rounded" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Company Detail Page Skeleton
+export function CompanyDetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-black pt-20 text-white">
+      <div className="relative z-10 mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+        {/* Back Link */}
+        <div className="mb-8 flex items-center gap-2">
+          <Skeleton className="h-4 w-12 rounded" />
+        </div>
+
+        {/* Company Profile Header */}
+        <div className="mb-12 overflow-hidden rounded-3xl border border-zinc-800/80 bg-zinc-900/40 p-6 backdrop-blur-xl sm:p-8 md:p-10">
+          <div className="flex flex-col items-center gap-8 md:flex-row md:items-start md:gap-10">
+            {/* Studio Logo */}
+            <Skeleton className="aspect-[4/3] w-[220px] rounded-2xl" />
+
+            {/* Company Info */}
+            <div className="w-full flex-1 space-y-4 text-center md:text-left">
+              <div className="flex flex-wrap items-center justify-center gap-3 md:justify-start">
+                <Skeleton className="h-10 w-48 rounded-lg sm:h-12" />
+                <Skeleton className="h-6 w-12 rounded-full" />
+              </div>
+
+              {/* Meta information tags */}
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-4 md:justify-start">
+                <Skeleton className="h-4 w-32 rounded" />
+                <Skeleton className="h-4 w-28 rounded" />
+                <Skeleton className="h-4 w-24 rounded" />
+              </div>
+
+              {/* Description */}
+              <div className="mt-5 space-y-2">
+                <Skeleton className="h-4 w-full rounded" />
+                <Skeleton className="h-4 w-11/12 rounded" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Filter and Control Bar */}
+        <div className="mb-8 flex flex-col gap-4 border-b border-zinc-800/80 pb-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-10 w-28 rounded-xl" />
+            <Skeleton className="h-10 w-28 rounded-xl" />
+            <Skeleton className="h-10 w-28 rounded-xl" />
+          </div>
+          <Skeleton className="h-10 w-44 rounded-xl" />
+        </div>
+
+        {/* Media Catalog Grid */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Search Page Skeleton
+export function SearchPageSkeleton() {
+  return (
+    <div className="min-h-screen bg-zinc-950 px-6 pt-24 pb-12 sm:px-16">
+      {/* Search bar */}
+      <Skeleton className="mb-8 h-12 w-full max-w-2xl rounded-full" />
+
+      {/* Type filters */}
+      <div className="mb-8 flex gap-2">
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-20 rounded-full" />
+      </div>
+
+      {/* Results grid */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {Array.from({ length: 18 }).map((_, i) => (
+          <CardSkeleton key={i} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/lib/tmdb-actions.ts
+++ b/lib/tmdb-actions.ts
@@ -174,33 +174,37 @@ export async function getByCategory(genreName: string): Promise<TMDBMedia[]> {
 // Get specific details for Quick View / Detail Page (including videos/trailer, watch providers, logo, and recommendations)
 export async function getMediaDetails(mediaType: "movie" | "tv", id: string) {
   try {
-    const regionDataPromise = (
-      mediaType === "movie"
-        ? axios.get(`/movie/${id}/release_dates`)
-        : axios.get(`/tv/${id}/content_ratings`)
-    ).catch(() => ({ data: { results: [] } }));
+    const regionAppend = mediaType === "movie" ? "release_dates" : "content_ratings";
 
-    const [detailsRes, creditsRes, videosRes, watchRes, recommendationsRes, regionDataRes] = await Promise.all([
-      axios.get(`/${mediaType}/${id}`),
-      axios.get(`/${mediaType}/${id}/credits`),
-      axios.get(`/${mediaType}/${id}/videos`),
-      axios.get(`/${mediaType}/${id}/watch/providers`),
-      axios.get(`/${mediaType}/${id}/recommendations`),
-      regionDataPromise,
-    ]);
+    // Single TMDB request — images, credits, videos, providers, recommendations all appended
+    const res = await axios.get(`/${mediaType}/${id}`, {
+      params: {
+        append_to_response: `credits,videos,watch/providers,recommendations,images,${regionAppend}`,
+        include_image_language: "en,null",
+      },
+    });
 
-    const { logoPath, textlessPosterPath } = await getMediaImages(mediaType, Number(id));
-    const recommendations = cleanMediaData(recommendationsRes.data.results || [], mediaType);
+    const data = res.data;
+    const logos = (data.images?.logos || []) as TMDBLogo[];
+    const posters = (data.images?.posters || []) as TMDBPoster[];
+
+    const englishLogo = logos.find((l) => l.iso_639_1 === "en");
+    const logoPath: string | null = logos.length > 0 ? ((englishLogo || logos[0]).file_path ?? null) : null;
+
+    const textlessPoster = posters.find((p) => p.iso_639_1 === null);
+    const textlessPosterPath: string | null = posters.length > 0 ? ((textlessPoster || posters[0]).file_path ?? null) : null;
+
+    const recommendations = cleanMediaData(data.recommendations?.results || [], mediaType);
 
     return {
-      details: detailsRes.data,
-      credits: creditsRes.data,
-      videos: videosRes.data.results || [],
-      watchProviders: watchRes.data.results || {},
+      details: data,
+      credits: data.credits ?? { cast: [], crew: [] },
+      videos: data.videos?.results || [],
+      watchProviders: data["watch/providers"]?.results || {},
       logoPath,
       textlessPosterPath,
       recommendations,
-      regionalData: regionDataRes.data.results || [],
+      regionalData: data[regionAppend]?.results || [],
     };
   } catch (error) {
     console.error(`Error fetching details for ${mediaType} ${id}:`, error);


### PR DESCRIPTION
- Refactored `/movie`, `/tv`, `/person`, `/search`, and `/company` page components to immediately render client shells.
- Created internal API endpoints under `/api/tmdb/*` with optimized parallel fetching and revalidation configs to server client requests.
- Integrated `append_to_response` in TMDB media detail action to decrease TMDB request roundtrips to one single fetch.
- Replaced manual URL sync mechanism in search page with nuqs `useQueryState` for automatic URL state synchronization.
- Designed premium skeletons (`HeroSkeleton`, `MediaDetailSkeleton`, `PersonDetailSkeleton`, `CompanyDetailSkeleton`) matching layout layouts.
- Fixed cascading React render warnings and resolved all compilation warnings and strict type-safety issues.
- Added custom chart styles to override default SVG focus rings in globals.css.