### PR TITLE
feat(navigation): bind Quick View and Auth modals to URL query state …

### DIFF
--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  Suspense,
+} from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -27,7 +34,7 @@ import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import { TMDBMedia } from "@/lib/tmdb";
 import { siteConfig } from "@/config/site";
 
-export default function ChatPage() {
+function ChatPageContent() {
   const router = useRouter();
   const confirm = useConfirm();
   const session = authClient.useSession();
@@ -132,13 +139,19 @@ export default function ChatPage() {
     } as TMDBMedia;
   }, [quickViewMediaRef]);
 
-  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
-    if (media) {
-      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
-    } else {
-      setQuickViewMediaRef(null);
-    }
-  }, [setQuickViewMediaRef]);
+  const setQuickViewMedia = useCallback(
+    (media: TMDBMedia | null) => {
+      if (media) {
+        setQuickViewMediaRef({
+          id: String(media.id),
+          media_type: media.media_type || "movie",
+        });
+      } else {
+        setQuickViewMediaRef(null);
+      }
+    },
+    [setQuickViewMediaRef],
+  );
 
   const isQuickViewOpen = quickViewMedia !== null;
 
@@ -252,7 +265,10 @@ export default function ChatPage() {
       });
     } catch (err: unknown) {
       const errorObj = err as { message?: string };
-      if (errorObj.message?.includes("privacy settings") || errorObj.message?.includes("direct messaging")) {
+      if (
+        errorObj.message?.includes("privacy settings") ||
+        errorObj.message?.includes("direct messaging")
+      ) {
         setIsPrivacyErrorOpen(true);
       } else {
         toast.error(errorObj.message || "Failed to send message");
@@ -292,7 +308,10 @@ export default function ChatPage() {
       });
     } catch (err: unknown) {
       const errorObj = err as { message?: string };
-      if (errorObj.message?.includes("privacy settings") || errorObj.message?.includes("direct messaging")) {
+      if (
+        errorObj.message?.includes("privacy settings") ||
+        errorObj.message?.includes("direct messaging")
+      ) {
         setIsPrivacyErrorOpen(true);
       } else {
         toast.error(errorObj.message || "Failed to send GIF");
@@ -404,10 +423,15 @@ export default function ChatPage() {
       setIsNewChatOpen(false);
     } catch (err: unknown) {
       const errorObj = err as { message?: string };
-      if (errorObj.message?.includes("privacy settings") || errorObj.message?.includes("direct messaging")) {
+      if (
+        errorObj.message?.includes("privacy settings") ||
+        errorObj.message?.includes("direct messaging")
+      ) {
         setIsPrivacyErrorOpen(true);
       } else {
-        toast.error(errorObj.message || "Failed to start direct message session");
+        toast.error(
+          errorObj.message || "Failed to start direct message session",
+        );
       }
     }
   };
@@ -591,5 +615,13 @@ export default function ChatPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function ChatPage() {
+  return (
+    <Suspense>
+      <ChatPageContent />
+    </Suspense>
   );
 }

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -23,6 +23,7 @@ import ChatWorkspace from "@/components/chat/chat-workspace";
 import DetailsPanel from "@/components/chat/details-panel";
 import ChatModals from "@/components/chat/chat-modals";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import { TMDBMedia } from "@/lib/tmdb";
 import { siteConfig } from "@/config/site";
 
@@ -121,8 +122,25 @@ export default function ChatPage() {
   const [activeContextMenuMessageId, setActiveContextMenuMessageId] = useState<
     string | null
   >(null);
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
-  const [isQuickViewOpen, setIsQuickViewOpen] = useState(false);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
+
+  const isQuickViewOpen = quickViewMedia !== null;
 
   // Modals
   const [isNewChatOpen, setIsNewChatOpen] = useState(false);
@@ -511,7 +529,6 @@ export default function ChatPage() {
         handleDeleteMessage={handleDeleteMessage}
         onQuickView={(media) => {
           setQuickViewMedia(media);
-          setIsQuickViewOpen(true);
         }}
       />
 
@@ -568,7 +585,6 @@ export default function ChatPage() {
         <QuickViewModal
           isOpen={isQuickViewOpen}
           onClose={() => {
-            setIsQuickViewOpen(false);
             setQuickViewMedia(null);
           }}
           media={quickViewMedia}

--- a/app/(main)/lists/[id]/page.tsx
+++ b/app/(main)/lists/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, use, useEffect } from "react";
+import React, { useState, use, useEffect, useMemo, useCallback } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
@@ -51,6 +51,7 @@ import { useRouter } from "next/navigation";
 import { searchMedia } from "@/lib/tmdb-actions";
 import { TMDBMedia } from "@/lib/tmdb";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import { useConfirm } from "@/components/ui/confirm-provider";
 import { siteConfig } from "@/config/site";
 
@@ -190,7 +191,23 @@ export default function CustomListDetailPage({
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [isMembersOpen, setIsMembersOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
-  const [selectedMedia, setSelectedMedia] = useState<TMDBMedia | null>(null);
+  const [selectedMediaRef, setSelectedMediaRef] = useQuickViewMediaState();
+
+  const selectedMedia = useMemo<TMDBMedia | null>(() => {
+    if (!selectedMediaRef) return null;
+    return {
+      id: Number(selectedMediaRef.id),
+      media_type: selectedMediaRef.media_type,
+    } as TMDBMedia;
+  }, [selectedMediaRef]);
+
+  const setSelectedMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setSelectedMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setSelectedMediaRef(null);
+    }
+  }, [setSelectedMediaRef]);
 
   // Edit list states
   const [editName, setEditName] = useState("");

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,4 +1,5 @@
 import HomeClient from "@/components/home-client";
+import { Suspense } from "react";
 
 export const metadata = {
   title: "PopcornVision — Watch Movies & TV Shows Free",
@@ -7,5 +8,9 @@ export const metadata = {
 };
 
 export default function Page() {
-  return <HomeClient />;
+  return (
+    <Suspense>
+      <HomeClient />
+    </Suspense>
+  );
 }

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useMemo } from "react";
+import { useState, useRef, useMemo, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -90,9 +90,7 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
   const [hideRatings, setHideRatings] = useState(
     convexProfile?.hideRatings === true,
   );
-  const [hideDiary, setHideDiary] = useState(
-    convexProfile?.hideDiary === true,
-  );
+  const [hideDiary, setHideDiary] = useState(convexProfile?.hideDiary === true);
   const [hideInsights, setHideInsights] = useState(
     convexProfile?.hideInsights === true,
   );
@@ -394,7 +392,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Delete Account",
-        description: "Are you absolutely sure you want to delete your account? This action is permanent and cannot be undone.",
+        description:
+          "Are you absolutely sure you want to delete your account? This action is permanent and cannot be undone.",
         confirmText: "Delete",
       }))
     ) {
@@ -449,7 +448,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Close Account",
-        description: "Are you sure you want to close your account? You will be logged out, but you can reopen your account anytime simply by logging back in.",
+        description:
+          "Are you sure you want to close your account? You will be logged out, but you can reopen your account anytime simply by logging back in.",
         confirmText: "Close Account",
       }))
     ) {
@@ -484,7 +484,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Clear Diary Data",
-        description: "Are you sure you want to delete all your diary entries and watch history? This action is permanent and cannot be undone.",
+        description:
+          "Are you sure you want to delete all your diary entries and watch history? This action is permanent and cannot be undone.",
         confirmText: "Clear All",
       }))
     ) {
@@ -507,7 +508,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Clear Watchlist Data",
-        description: "Are you sure you want to delete all items from your watchlist? This action is permanent and cannot be undone.",
+        description:
+          "Are you sure you want to delete all items from your watchlist? This action is permanent and cannot be undone.",
         confirmText: "Clear All",
       }))
     ) {
@@ -530,7 +532,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Clear Favorites Data",
-        description: "Are you sure you want to delete all items from your favorites list? This action is permanent and cannot be undone.",
+        description:
+          "Are you sure you want to delete all items from your favorites list? This action is permanent and cannot be undone.",
         confirmText: "Clear All",
       }))
     ) {
@@ -553,7 +556,8 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
     if (
       !(await confirm({
         title: "Clear Ratings Data",
-        description: "Are you sure you want to delete all your ratings? This will also remove rating values from your watch history. This action is permanent and cannot be undone.",
+        description:
+          "Are you sure you want to delete all your ratings? This will also remove rating values from your watch history. This action is permanent and cannot be undone.",
         confirmText: "Clear All",
       }))
     ) {
@@ -687,7 +691,7 @@ function SettingsForm({ convexProfile, user }: SettingsFormProps) {
   );
 }
 
-export default function SettingsPage() {
+function SettingsPageContent() {
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
   const loadingSession = session.isPending;
@@ -744,5 +748,13 @@ export default function SettingsPage() {
 
       <SettingsForm convexProfile={convexProfile || null} user={user || {}} />
     </div>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense>
+      <SettingsPageContent />
+    </Suspense>
   );
 }

--- a/app/(main)/user/[username]/page.tsx
+++ b/app/(main)/user/[username]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, use, useEffect } from "react";
+import { useState, use, useEffect, useMemo, useCallback } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { useQueryState } from "nuqs";
 import { api } from "@/convex/_generated/api";
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import { TMDBMedia } from "@/lib/tmdb";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -49,7 +50,23 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   const { username } = use(params);
   const confirm = useConfirm();
   const openAuth = useAuthModalStore((state) => state.open);
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
   const [activeTabState, setActiveTab] = useQueryState("tab", {
     defaultValue: "all",
   });

--- a/components/company-detail-client.tsx
+++ b/components/company-detail-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, Suspense, useEffect } from "react";
+import { useState, useMemo, Suspense, useEffect, useCallback } from "react";
 import { TMDBMedia } from "@/lib/tmdb";
 import { TMDBCompanyDetails } from "@/lib/tmdb-actions";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Card from "@/components/card";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import AuthModal from "@/components/auth-modal";
 import {
   Select,
@@ -68,7 +69,23 @@ export default function CompanyDetailClient({
 
   const [mediaFilter, setMediaFilter] = useState<MediaFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("popularity");
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
 
   // Combine and deduplicate movies & tv shows
   const mergedMedia = useMemo(() => {

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { TMDBMedia } from "@/lib/tmdb";
 import {
   getTrending,
@@ -11,6 +11,7 @@ import Hero from "./hero";
 import Section from "./section";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
 import QuickViewModal from "./quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { authClient } from "@/lib/auth-client";
@@ -28,7 +29,23 @@ import Card from "./card";
 
 export default function HomeClient() {
   const openAuth = useAuthModalStore((state) => state.open);
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
 
   const [heroItems, setHeroItems] = useState<TMDBMedia[]>([]);
   const [trendingItems, setTrendingItems] = useState<TMDBMedia[]>([]);

--- a/components/media-detail-client.tsx
+++ b/components/media-detail-client.tsx
@@ -23,6 +23,7 @@ import Carousel from "./carousel";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
 import QuickViewModal from "./quick-view-modal";
 import PersonQuickViewModal from "./person-quick-view-modal";
+import { useQuickViewMediaState, useQuickViewPersonState } from "@/hooks/use-query-modal-state";
 import CommentsSection from "@/components/comments-section";
 import LogWatchModal from "./log-watch-modal";
 import { getCollectionDetails, getSeasonDetails } from "@/lib/tmdb-actions";
@@ -189,10 +190,24 @@ export default function MediaDetailClient({
   const setEpisode = useCallback((e: number) => {
     setEpisodeState(String(e));
   }, [setEpisodeState]);
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
-  const [quickViewPersonId, setQuickViewPersonId] = useState<number | null>(
-    null,
-  );
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+  const [quickViewPersonId, setQuickViewPersonId] = useQuickViewPersonState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
 
   const [selectedRegion, setSelectedRegion] = useState("US");
 

--- a/components/person-detail-client.tsx
+++ b/components/person-detail-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, Suspense, useEffect } from "react";
+import { useState, useMemo, Suspense, useEffect, useCallback } from "react";
 import { TMDBMedia, cleanMediaData, TMDBRawItem } from "@/lib/tmdb";
 import { useAuthModalStore } from "@/lib/auth-modal-store";
 import { PersonDetailSkeleton } from "@/components/skeletons";
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import Card from "@/components/card";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import AuthModal from "@/components/auth-modal";
 import moment from "moment";
 import {
@@ -92,7 +93,23 @@ export default function PersonDetailClient({
   const [mediaFilter, setMediaFilter] = useState<MediaFilter>("all");
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("popularity");
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
 
   // Merge cast & crew details uniquely
   const mergedCredits = useMemo(() => {

--- a/components/profile/insights-tab.tsx
+++ b/components/profile/insights-tab.tsx
@@ -9,6 +9,7 @@ import {
   searchPersonByName,
 } from "@/lib/tmdb-actions";
 import PersonQuickViewModal from "@/components/person-quick-view-modal";
+import { useQuickViewPersonState } from "@/hooks/use-query-modal-state";
 import {
   BarChart,
   Bar,
@@ -64,8 +65,7 @@ export function InsightsTab({ diary, user }: InsightsTabProps) {
   const [metadata, setMetadata] = useState<Record<string, StatsMetadata>>({});
   const [loading, setLoading] = useState(false);
   const [searchingPerson, setSearchingPerson] = useState<string | null>(null);
-  const [selectedPersonId, setSelectedPersonId] = useState<number | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [selectedPersonId, setSelectedPersonId] = useQuickViewPersonState();
 
   const handlePersonClick = async (name: string) => {
     if (searchingPerson) return;
@@ -74,7 +74,6 @@ export function InsightsTab({ diary, user }: InsightsTabProps) {
       const id = await searchPersonByName(name);
       if (id) {
         setSelectedPersonId(id);
-        setIsModalOpen(true);
       } else {
         router.push(`/search?q=${encodeURIComponent(name)}`);
       }
@@ -833,8 +832,8 @@ export function InsightsTab({ diary, user }: InsightsTabProps) {
         </>
       )}
       <PersonQuickViewModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        isOpen={selectedPersonId !== null}
+        onClose={() => setSelectedPersonId(null)}
         personId={selectedPersonId}
       />
     </div>

--- a/components/quick-view-modal.tsx
+++ b/components/quick-view-modal.tsx
@@ -33,6 +33,8 @@ import moment from "moment";
 import isoCountries from "@/data/iso-3166.json";
 
 interface MediaDetails {
+  title?: string;
+  name?: string;
   tagline?: string;
   runtime?: number;
   number_of_seasons?: number;
@@ -44,6 +46,11 @@ interface MediaDetails {
     name: string;
     profile_path: string | null;
   }[];
+  release_date?: string;
+  first_air_date?: string;
+  vote_average?: number;
+  backdrop_path?: string | null;
+  poster_path?: string | null;
 }
 
 interface CrewItem {
@@ -184,13 +191,21 @@ export default function QuickViewModal({
 
   const releaseYear = media.release_date
     ? new Date(media.release_date).getFullYear()
-    : "N/A";
+    : details?.release_date
+      ? new Date(details.release_date).getFullYear()
+      : details?.first_air_date
+        ? new Date(details.first_air_date).getFullYear()
+        : "N/A";
   const voteRating = media.vote_average
     ? media.vote_average.toFixed(media.vote_average < 10 ? 1 : 0)
-    : "0.0";
+    : details?.vote_average
+      ? details.vote_average.toFixed(details.vote_average < 10 ? 1 : 0)
+      : "0.0";
   const backdropUrl = media.backdrop_path
     ? `https://image.tmdb.org/t/p/w780${media.backdrop_path}`
-    : "/logo/popcorn.png";
+    : details?.backdrop_path
+      ? `https://image.tmdb.org/t/p/w780${details.backdrop_path}`
+      : "/logo/popcorn.png";
 
   // YouTube trailer resolution
   const trailerVideo = videos?.find(
@@ -216,9 +231,9 @@ export default function QuickViewModal({
         await addToWatchlist({
           mediaId: mId,
           mediaType: mType,
-          title: media.title || media.name || "",
-          posterPath: media.poster_path || "",
-          rating: media.vote_average || 0,
+          title: media.title || media.name || details?.title || details?.name || "",
+          posterPath: media.poster_path || details?.poster_path || "",
+          rating: media.vote_average || details?.vote_average || 0,
           releaseYear: releaseYear.toString(),
         });
       }
@@ -245,9 +260,9 @@ export default function QuickViewModal({
         await addToFavorites({
           mediaId: mId,
           mediaType: mType,
-          title: media.title || media.name || "",
-          posterPath: media.poster_path || "",
-          rating: media.vote_average || 0,
+          title: media.title || media.name || details?.title || details?.name || "",
+          posterPath: media.poster_path || details?.poster_path || "",
+          rating: media.vote_average || details?.vote_average || 0,
           releaseYear: releaseYear.toString(),
         });
       }
@@ -264,7 +279,7 @@ export default function QuickViewModal({
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="h-[85svh] w-[calc(100%-2rem)] max-w-7xl overflow-hidden rounded-3xl border border-zinc-800 bg-zinc-950 p-0 text-white shadow-2xl backdrop-blur-xl sm:h-[80svh] sm:max-w-7xl md:h-[85svh]">
         <DialogTitle className="sr-only">
-          Quick View: {media.title || media.name}
+          Quick View: {media.title || media.name || details?.title || details?.name || "Media Details"}
         </DialogTitle>
         <DialogDescription className="sr-only">
           Official trailer and details overview
@@ -315,14 +330,14 @@ export default function QuickViewModal({
                   <div className="relative mb-2 flex h-16 max-w-[85%] items-center sm:h-20 md:h-24 lg:h-28">
                     <img
                       src={`https://image.tmdb.org/t/p/w500${logoPath}`}
-                      alt={media.title || media.name}
+                      alt={media.title || media.name || details?.title || details?.name || ""}
                       className="h-full w-auto object-contain drop-shadow-[0_4px_8px_rgba(0,0,0,0.8)] filter"
                       onError={() => setLogoError(true)}
                     />
                   </div>
                 ) : (
                   <h2 className="text-2xl font-extrabold tracking-tight sm:text-3xl">
-                    {media.title || media.name}
+                    {media.title || media.name || details?.title || details?.name}
                   </h2>
                 )}
                 {details?.tagline && (

--- a/components/search-client.tsx
+++ b/components/search-client.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useRef,
   Suspense,
+  useMemo,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
@@ -27,6 +28,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import QuickViewModal from "@/components/quick-view-modal";
+import { useQuickViewMediaState } from "@/hooks/use-query-modal-state";
 import AuthModal from "@/components/auth-modal";
 import { Input } from "@/components/ui/input";
 import {
@@ -187,7 +189,23 @@ export default function SearchClient({
   });
   const [results, setResults] = useState<TMDBMedia[]>([]);
   const [isPending, startTransition] = useTransition();
-  const [quickViewMedia, setQuickViewMedia] = useState<TMDBMedia | null>(null);
+  const [quickViewMediaRef, setQuickViewMediaRef] = useQuickViewMediaState();
+
+  const quickViewMedia = useMemo<TMDBMedia | null>(() => {
+    if (!quickViewMediaRef) return null;
+    return {
+      id: Number(quickViewMediaRef.id),
+      media_type: quickViewMediaRef.media_type,
+    } as TMDBMedia;
+  }, [quickViewMediaRef]);
+
+  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
+    if (media) {
+      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
+    } else {
+      setQuickViewMediaRef(null);
+    }
+  }, [setQuickViewMediaRef]);
 
   // Advanced Filters State using nuqs useQueryState
   const [genre, setGenre] = useQueryState("genre", { defaultValue: "" });

--- a/hooks/use-query-modal-state.ts
+++ b/hooks/use-query-modal-state.ts
@@ -1,0 +1,39 @@
+import { useQueryState, parseAsBoolean, parseAsInteger, createParser } from "nuqs";
+import { QUERY_PARAMS } from "@/lib/constants";
+
+export interface MediaRef {
+  id: string;
+  media_type: "movie" | "tv";
+}
+
+export const parseAsMediaRef = createParser<MediaRef>({
+  parse(value) {
+    const [type, id] = value.split("-");
+    if (!type || !id || (type !== "movie" && type !== "tv")) return null;
+    return { id, media_type: type as "movie" | "tv" };
+  },
+  serialize(value) {
+    return `${value.media_type}-${value.id}`;
+  }
+});
+
+export function useQuickViewMediaState() {
+  return useQueryState(
+    QUERY_PARAMS.QUICK_VIEW,
+    parseAsMediaRef.withOptions({ history: "push" })
+  );
+}
+
+export function useQuickViewPersonState() {
+  return useQueryState(
+    QUERY_PARAMS.PERSON,
+    parseAsInteger.withOptions({ history: "push" })
+  );
+}
+
+export function useAuthQueryState() {
+  return useQueryState(
+    QUERY_PARAMS.AUTH,
+    parseAsBoolean.withDefault(false).withOptions({ history: "push" })
+  );
+}

--- a/lib/auth-modal-store.ts
+++ b/lib/auth-modal-store.ts
@@ -1,13 +1,26 @@
-import { create } from "zustand";
+import { useQueryState, parseAsBoolean } from "nuqs";
+import { QUERY_PARAMS } from "@/lib/constants";
 
-interface AuthModalStore {
-  isOpen: boolean;
-  open: () => void;
-  close: () => void;
+export function useAuthModalStore<T = { isOpen: boolean; open: () => void; close: () => void }>(
+  selector?: (state: { isOpen: boolean; open: () => void; close: () => void }) => T
+): T {
+  const [isOpenState, setIsOpenState] = useQueryState(
+    QUERY_PARAMS.AUTH,
+    parseAsBoolean.withDefault(false).withOptions({ history: "push" })
+  );
+
+  const state = {
+    isOpen: isOpenState,
+    open: () => {
+      setIsOpenState(true);
+    },
+    close: () => {
+      setIsOpenState(false);
+    },
+  };
+
+  if (selector) {
+    return selector(state);
+  }
+  return state as unknown as T;
 }
-
-export const useAuthModalStore = create<AuthModalStore>((set) => ({
-  isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-}));

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,3 +8,9 @@ export const USER_LOCATION = "user-location";
 export const AND_SEPARATION = "AND";
 export const OR_SEPARATION = "OR";
 export const DISCLAIMER_READ = "disclaimer-read";
+
+export const QUERY_PARAMS = {
+  QUICK_VIEW: "quick-view",
+  PERSON: "person",
+  AUTH: "auth",
+} as const;


### PR DESCRIPTION
…using nuqs

- Store query parameter keys in `lib/constants.ts` (using `quick-view`, `person`, and `auth`)
- Create shared hooks in `hooks/use-query-modal-state.ts` using built-in and custom nuqs parsers
- Refactor `useAuthModalStore` hook to sync auth modal directly with `?auth=true` query param
- Update `quick-view-modal.tsx` to handle partial media props and fallback to API details for deep-linking
- Replace local `useState` in pages and client components with query state for media quick view, person quick view, and auth modal