### PR TITLE
feat(sw): temporarily disable quick reply action in push notifications

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -2,7 +2,7 @@ import HomeClient from "@/components/home-client";
 import { Suspense } from "react";
 
 export const metadata = {
-  title: "PopcornVision — Watch Movies & TV Shows Free",
+  title: "Popcorn Vision - Watch Movies & TV Shows Free",
   description:
     "Discover, track, and watch movies and TV shows for free on PopcornVision.",
 };

--- a/app/(main)/privacy/page.tsx
+++ b/app/(main)/privacy/page.tsx
@@ -12,13 +12,13 @@ export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-zinc-950 py-16 text-zinc-300 md:py-24">
       {/* Background glow effects */}
-      <div className="absolute top-0 left-1/4 -z-10 h-[500px] w-[500px] rounded-full bg-primary/5 blur-3xl" />
+      <div className="bg-primary/5 absolute top-0 left-1/4 -z-10 h-[500px] w-[500px] rounded-full blur-3xl" />
       <div className="absolute top-1/3 right-1/4 -z-10 h-[550px] w-[550px] rounded-full bg-zinc-900/40 blur-3xl" />
 
       <div className="mx-auto max-w-4xl px-6 md:px-8">
         {/* Header Section */}
         <div className="mb-12 border-b border-zinc-900 pb-8 text-center md:text-left">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900 text-primary md:mx-0">
+          <div className="text-primary mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900 md:mx-0">
             <Shield className="h-6 w-6" />
           </div>
           <h1 className="bg-linear-to-r from-white via-zinc-200 to-zinc-400 bg-clip-text text-3xl font-extrabold tracking-tight text-transparent sm:text-4xl">
@@ -33,28 +33,47 @@ export default function PrivacyPage() {
         <div className="space-y-10 leading-relaxed">
           <section className="space-y-4">
             <p className="text-base text-zinc-400">
-              At <strong>{siteConfig.name}</strong>, we deeply respect and commit to protecting your personal data. This Privacy Policy page explains the types of information we collect, how we manage it, and your rights regarding that data.
+              At <strong>{siteConfig.name}</strong>, we deeply respect and
+              commit to protecting your personal data. This Privacy Policy page
+              explains the types of information we collect, how we manage it,
+              and your rights regarding that data.
             </p>
           </section>
 
           {/* Card: Information We Collect */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <Eye className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">1. Information We Collect</h2>
+              <Eye className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                1. Information We Collect
+              </h2>
             </div>
             <p className="text-sm">
-              We collect information to provide a more personalized movie tracking experience and enhance social interactions on our platform:
+              We collect information to provide a more personalized movie
+              tracking experience and enhance social interactions on our
+              platform:
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
               <li>
-                <strong className="text-zinc-300">Account Information:</strong> When you sign up through our authentication provider, we receive basic information such as your name, email address, profile picture, and the username you create.
+                <strong className="text-zinc-300">Account Information:</strong>{" "}
+                When you sign up through our authentication provider, we receive
+                basic information such as your name, email address, profile
+                picture, and the username you create.
               </li>
               <li>
-                <strong className="text-zinc-300">Activity Data:</strong> We store lists of movies or TV shows you mark as favorites, your watch logs (diary), your watchlists, as well as the ratings and reviews you submit.
+                <strong className="text-zinc-300">Activity Data:</strong> We
+                store lists of movies or TV shows you mark as favorites, your
+                watch logs (diary), your watchlists, as well as the ratings and
+                reviews you submit.
               </li>
               <li>
-                <strong className="text-zinc-300">Device & Analytical Info:</strong> We collect non-personal data such as browser type, operating system, IP address, and your interactions on our website through analytics services like Google Analytics for performance optimization.
+                <strong className="text-zinc-300">
+                  Device & Analytical Info:
+                </strong>{" "}
+                We collect non-personal data such as browser type, operating
+                system, IP address, and your interactions on our website through
+                analytics services like Google Analytics for performance
+                optimization.
               </li>
             </ul>
           </section>
@@ -62,38 +81,64 @@ export default function PrivacyPage() {
           {/* Card: How We Use Information */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <Lock className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">2. How We Use Your Information</h2>
+              <Lock className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                2. How We Use Your Information
+              </h2>
             </div>
-            <p className="text-sm">
-              The information we collect is used to:
-            </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
-              <li>Provide, maintain, and improve the social and tracking features on {siteConfig.name}.</li>
-              <li>Personalize user experience, including displaying your statistical watch insights (Insights).</li>
-              <li>Secure your account and prevent abuse or suspicious activity on the platform.</li>
-              <li>Analyze usage trends to design new features and interface improvements.</li>
+            <p className="text-sm">The information we collect is used to:</p>
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
+              <li>
+                Provide, maintain, and improve the social and tracking features
+                on {siteConfig.name}.
+              </li>
+              <li>
+                Personalize user experience, including displaying your
+                statistical watch insights (Insights).
+              </li>
+              <li>
+                Secure your account and prevent abuse or suspicious activity on
+                the platform.
+              </li>
+              <li>
+                Analyze usage trends to design new features and interface
+                improvements.
+              </li>
             </ul>
           </section>
 
           {/* Card: Sharing Information */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <Globe className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">3. Sharing Information with Third Parties</h2>
+              <Globe className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                3. Sharing Information with Third Parties
+              </h2>
             </div>
             <p className="text-sm">
-              We <strong>never sell or rent</strong> your personal information to any third parties. We only share your data in the following scenarios:
+              We <strong>never sell or rent</strong> your personal information
+              to any third parties. We only share your data in the following
+              scenarios:
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
               <li>
-                <strong className="text-zinc-300">Authentication & Database Services:</strong> Your data is securely processed by the Convex distributed database and the Better Auth authentication system.
+                <strong className="text-zinc-300">
+                  Authentication & Database Services:
+                </strong>{" "}
+                Your data is securely processed by the Convex distributed
+                database and the Better Auth authentication system.
               </li>
               <li>
-                <strong className="text-zinc-300">Third-Party API Providers (TMDb):</strong> We use the TMDb API to fetch movie metadata. However, no personal information is transmitted to TMDb.
+                <strong className="text-zinc-300">
+                  Third-Party API Providers (TMDb):
+                </strong>{" "}
+                We use the TMDb API to fetch movie metadata. However, no
+                personal information is transmitted to TMDb.
               </li>
               <li>
-                <strong className="text-zinc-300">Legal Compliance:</strong> We may disclose your information if required by law or a court order from authorized agencies.
+                <strong className="text-zinc-300">Legal Compliance:</strong> We
+                may disclose your information if required by law or a court
+                order from authorized agencies.
               </li>
             </ul>
           </section>
@@ -101,28 +146,27 @@ export default function PrivacyPage() {
           {/* Card: User Rights */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <FileText className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">4. Security & Your Rights</h2>
+              <FileText className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                4. Security & Your Rights
+              </h2>
             </div>
             <p className="text-sm">
-              Data security is our top priority. We use modern encryption to protect data exchange on this platform. In addition, you have full control over your privacy:
+              Data security is our top priority. We use modern encryption to
+              protect data exchange on this platform. In addition, you have full
+              control over your privacy:
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
               <li>
-                You can adjust your profile privacy settings (Public, Friends Only, or Private) and hide your watchlist/diary from other users in your <strong>Privacy Settings</strong>.
+                You can adjust your profile privacy settings (Public, Friends
+                Only, or Private) and hide your watchlist/diary from other users
+                in your <strong>Privacy Settings</strong>.
               </li>
               <li>
-                You have the right to download a copy of your log data or request permanent deletion of your account at any time.
+                You have the right to download a copy of your log data or
+                request permanent deletion of your account at any time.
               </li>
             </ul>
-          </section>
-
-          {/* Contact Us */}
-          <section className="border-t border-zinc-900 pt-8 text-center md:text-left">
-            <h2 className="text-base font-bold text-white">Contact Us</h2>
-            <p className="mt-1 text-xs text-zinc-500">
-              If you have any questions regarding this Privacy Policy, feel free to contact us at <Link href="https://fachryafrz.com">fachryafrz.com</Link>.
-            </p>
           </section>
         </div>
       </div>

--- a/app/(main)/terms/page.tsx
+++ b/app/(main)/terms/page.tsx
@@ -11,13 +11,13 @@ export default function TermsPage() {
   return (
     <main className="min-h-screen bg-zinc-950 py-16 text-zinc-300 md:py-24">
       {/* Background glow effects */}
-      <div className="absolute top-0 right-1/4 -z-10 h-[500px] w-[500px] rounded-full bg-primary/5 blur-3xl" />
+      <div className="bg-primary/5 absolute top-0 right-1/4 -z-10 h-[500px] w-[500px] rounded-full blur-3xl" />
       <div className="absolute top-1/3 left-1/4 -z-10 h-[550px] w-[550px] rounded-full bg-zinc-900/40 blur-3xl" />
 
       <div className="mx-auto max-w-4xl px-6 md:px-8">
         {/* Header Section */}
         <div className="mb-12 border-b border-zinc-900 pb-8 text-center md:text-left">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900 text-primary md:mx-0">
+          <div className="text-primary mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900 md:mx-0">
             <Scale className="h-6 w-6" />
           </div>
           <h1 className="bg-linear-to-r from-white via-zinc-200 to-zinc-400 bg-clip-text text-3xl font-extrabold tracking-tight text-transparent sm:text-4xl">
@@ -32,61 +32,96 @@ export default function TermsPage() {
         <div className="space-y-10 leading-relaxed">
           <section className="space-y-4">
             <p className="text-base text-zinc-400">
-              Welcome to <strong>{siteConfig.name}</strong>. The following Terms and Conditions govern your use of our website and services. By accessing or using our platform, you agree to be legally bound by this document.
+              Welcome to <strong>{siteConfig.name}</strong>. The following Terms
+              and Conditions govern your use of our website and services. By
+              accessing or using our platform, you agree to be legally bound by
+              this document.
             </p>
           </section>
 
           {/* Card: Account Registration */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <UserCheck className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">1. Registration & User Accounts</h2>
+              <UserCheck className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                1. Registration & User Accounts
+              </h2>
             </div>
             <p className="text-sm">
-              To enjoy all features of {siteConfig.name}, you must sign in or create an account through the authentication methods provided.
+              To enjoy all features of {siteConfig.name}, you must sign in or
+              create an account through the authentication methods provided.
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
-              <li>You are responsible for maintaining the confidentiality of your account credentials.</li>
-              <li>You must provide accurate information when creating your profile username.</li>
-              <li>An account must only be used by its rightful owner and cannot be transferred to others.</li>
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
+              <li>
+                You are responsible for maintaining the confidentiality of your
+                account credentials.
+              </li>
+              <li>
+                You must provide accurate information when creating your profile
+                username.
+              </li>
+              <li>
+                An account must only be used by its rightful owner and cannot be
+                transferred to others.
+              </li>
             </ul>
           </section>
 
           {/* Card: User Behavior */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <AlertCircle className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">2. Content & Conduct Policy</h2>
+              <AlertCircle className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                2. Content & Conduct Policy
+              </h2>
             </div>
             <p className="text-sm">
               As part of the {siteConfig.name} community, you agree not to:
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
-              <li>Submit movie reviews containing hate speech, discrimination, harassment, pornography, or other illegal content.</li>
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
+              <li>
+                Submit movie reviews containing hate speech, discrimination,
+                harassment, pornography, or other illegal content.
+              </li>
               <li>Engage in spam, scam, or manipulate ratings artificially.</li>
-              <li>Violate other users&apos; privacy by sharing their personal info without written consent.</li>
-              <li>Use bots or automated scripts to scrape data from our site without official permission.</li>
+              <li>
+                Violate other users&apos; privacy by sharing their personal info
+                without written consent.
+              </li>
+              <li>
+                Use bots or automated scripts to scrape data from our site
+                without official permission.
+              </li>
             </ul>
           </section>
 
           {/* Card: Disclaimer & Copyright */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <Info className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">3. Disclaimer & Video Content</h2>
+              <Info className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                3. Disclaimer & Video Content
+              </h2>
             </div>
             <p className="text-sm">
               Please understand the scope of our services:
             </p>
-            <ul className="list-disc pl-5 space-y-2 text-xs text-zinc-400">
+            <ul className="list-disc space-y-2 pl-5 text-xs text-zinc-400">
               <li>
-                {siteConfig.name} is strictly a movie logging, reviewing, and tracking service. We <strong>do not provide video streaming</strong> or direct downloads for copyrighted movies.
+                {siteConfig.name} is strictly a movie logging, reviewing, and
+                tracking service. We{" "}
+                <strong>do not provide video streaming</strong> or direct
+                downloads for copyrighted movies.
               </li>
               <li>
-                All movie information is compiled via a third-party API (TMDb). We do not guarantee 100% accuracy of this external data and are not responsible for any changes made by TMDb.
+                All movie information is compiled via a third-party API (TMDb).
+                We do not guarantee 100% accuracy of this external data and are
+                not responsible for any changes made by TMDb.
               </li>
               <li>
-                Logos, images, and movie posters presented on the site are promotional materials belonging to their respective original copyright holders.
+                Logos, images, and movie posters presented on the site are
+                promotional materials belonging to their respective original
+                copyright holders.
               </li>
             </ul>
           </section>
@@ -94,19 +129,16 @@ export default function TermsPage() {
           {/* Card: Termination & Changes */}
           <section className="space-y-4 rounded-3xl border border-zinc-900 bg-zinc-900/10 p-6 md:p-8">
             <div className="flex items-center gap-3 text-white">
-              <FileText className="h-5 w-5 text-primary" />
-              <h2 className="text-lg font-bold tracking-tight">4. Termination & Policy Updates</h2>
+              <FileText className="text-primary h-5 w-5" />
+              <h2 className="text-lg font-bold tracking-tight">
+                4. Termination & Policy Updates
+              </h2>
             </div>
             <p className="text-sm">
-              We reserve the right to suspend or permanently delete your account if repetitive violations of these Terms and Conditions are found. We may also update this document at any time. Changes will take effect immediately upon publication.
-            </p>
-          </section>
-
-          {/* Contact Us */}
-          <section className="border-t border-zinc-900 pt-8 text-center md:text-left">
-            <h2 className="text-base font-bold text-white">Contact Us</h2>
-            <p className="mt-1 text-xs text-zinc-500">
-              If you have any questions regarding these Terms and Conditions of use, reach out to us at support@popcornvision.com.
+              We reserve the right to suspend or permanently delete your account
+              if repetitive violations of these Terms and Conditions are found.
+              We may also update this document at any time. Changes will take
+              effect immediately upon publication.
             </p>
           </section>
         </div>

--- a/public/sw.js
+++ b/public/sw.js
@@ -24,16 +24,17 @@ self.addEventListener('push', function (event) {
       vibrate: [100, 50, 100],
     };
 
-    if (data.notificationType === 'chat_message' && data.chatId) {
-      options.actions = [
-        {
-          action: 'reply',
-          type: 'text',
-          title: 'Reply',
-          placeholder: 'Type a message...',
-        }
-      ];
-    }
+    // Disable quick reply action temporarily (on hold)
+    // if (data.notificationType === 'chat_message' && data.chatId) {
+    //   options.actions = [
+    //     {
+    //       action: 'reply',
+    //       type: 'text',
+    //       title: 'Reply',
+    //       placeholder: 'Type a message...',
+    //     }
+    //   ];
+    // }
 
     event.waitUntil(
       self.registration.showNotification(title, options)


### PR DESCRIPTION
Comments out the `options.actions` definition in the service worker's push event handler to put the quick reply feature on hold. The click handler logic is retained for easy reactivation in the future.