### PR TITLE
perf(client): optimize watchlist and favorite status queries

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -9,6 +9,7 @@ import { authClient } from "@/lib/auth-client";
 import { Star, Plus, Check, Heart, Loader2, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useUserLibrary } from "./user-library-provider";
 
 interface CardProps {
   media: TMDBMedia;
@@ -27,13 +28,9 @@ export default function Card({
   const [watchlistLoading, setWatchlistLoading] = useState(false);
   const [favoriteLoading, setFavoriteLoading] = useState(false);
 
-  // Read favorite status from Convex
-  const isFavorited = useQuery(
-    api.favorites.checkFavoriteItem,
-    isLoggedIn
-      ? { mediaId: String(media.id), mediaType: media.media_type || "movie" }
-      : "skip",
-  );
+  const { isWatchlisted: checkWatchlisted, isFavorited: checkFavorited } = useUserLibrary();
+  
+  const isFavorited = checkFavorited(media.id, media.media_type || "movie");
 
   const addToFavorites = useMutation(api.favorites.addToFavorites);
   const removeFromFavorites = useMutation(api.favorites.removeFromFavorites);
@@ -71,13 +68,7 @@ export default function Card({
     }
   };
 
-  // Read watchlist status from Convex
-  const isWatchlisted = useQuery(
-    api.watchlist.checkWatchlistItem,
-    isLoggedIn
-      ? { mediaId: String(media.id), mediaType: media.media_type || "movie" }
-      : "skip",
-  );
+  const isWatchlisted = checkWatchlisted(media.id, media.media_type || "movie");
 
   const addToWatchlist = useMutation(api.watchlist.addToWatchlist);
   const removeFromWatchlist = useMutation(api.watchlist.removeFromWatchlist);

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -8,6 +8,7 @@ import { api } from "@/convex/_generated/api";
 import { Play, Plus, Check, Star, Heart, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useUserLibrary } from "./user-library-provider";
 
 // Swiper imports
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -42,12 +43,9 @@ function HeroSlide({
   const [favoriteLoading, setFavoriteLoading] = useState(false);
   const [logoError, setLogoError] = useState(false);
 
-  const isFavorited = useQuery(
-    api.favorites.checkFavoriteItem,
-    isLoggedIn && media
-      ? { mediaId: String(media.id), mediaType: media.media_type || "movie" }
-      : "skip",
-  );
+  const { isWatchlisted: checkWatchlisted, isFavorited: checkFavorited } = useUserLibrary();
+
+  const isFavorited = checkFavorited(media.id, media.media_type || "movie");
 
   const addToFavorites = useMutation(api.favorites.addToFavorites);
   const removeFromFavorites = useMutation(api.favorites.removeFromFavorites);
@@ -85,12 +83,7 @@ function HeroSlide({
     }
   };
 
-  const isWatchlisted = useQuery(
-    api.watchlist.checkWatchlistItem,
-    isLoggedIn && media
-      ? { mediaId: String(media.id), mediaType: media.media_type || "movie" }
-      : "skip",
-  );
+  const isWatchlisted = checkWatchlisted(media.id, media.media_type || "movie");
 
   const addToWatchlist = useMutation(api.watchlist.addToWatchlist);
   const removeFromWatchlist = useMutation(api.watchlist.removeFromWatchlist);

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -26,6 +26,8 @@ import {
   Skeleton,
 } from "./skeletons";
 import Card from "./card";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 
 export default function HomeClient() {
   const openAuth = useAuthModalStore((state) => state.open);
@@ -39,13 +41,19 @@ export default function HomeClient() {
     } as TMDBMedia;
   }, [quickViewMediaRef]);
 
-  const setQuickViewMedia = useCallback((media: TMDBMedia | null) => {
-    if (media) {
-      setQuickViewMediaRef({ id: String(media.id), media_type: media.media_type || "movie" });
-    } else {
-      setQuickViewMediaRef(null);
-    }
-  }, [setQuickViewMediaRef]);
+  const setQuickViewMedia = useCallback(
+    (media: TMDBMedia | null) => {
+      if (media) {
+        setQuickViewMediaRef({
+          id: String(media.id),
+          media_type: media.media_type || "movie",
+        });
+      } else {
+        setQuickViewMediaRef(null);
+      }
+    },
+    [setQuickViewMediaRef],
+  );
 
   const [heroItems, setHeroItems] = useState<TMDBMedia[]>([]);
   const [trendingItems, setTrendingItems] = useState<TMDBMedia[]>([]);
@@ -68,6 +76,14 @@ export default function HomeClient() {
 
   const session = authClient.useSession();
   const isLoggedIn = !!session.data?.user;
+
+  const userProfile = useQuery(
+    api.users.getCurrentUser,
+    isLoggedIn ? {} : "skip",
+  );
+
+  const username = userProfile?.username || session.data?.user?.username;
+
   const continueWatching = useQuery(
     api.continueWatching.getProgress,
     isLoggedIn ? {} : "skip",
@@ -87,7 +103,10 @@ export default function HomeClient() {
         <HeroSkeleton />
         <div className="bg-background relative z-20 flex flex-col gap-6 pb-20">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20">
+            <div
+              key={i}
+              className="flex w-full flex-col gap-6 px-6 py-6 sm:px-16 md:px-20"
+            >
               <Skeleton className="h-6 w-44 rounded-md" />
               <CarouselSkeleton />
             </div>
@@ -161,9 +180,13 @@ export default function HomeClient() {
               </div>
             ) : watchlist.length > 0 ? (
               <div className="animate-in fade-in flex w-full flex-col gap-6 px-6 py-6 duration-300 sm:px-16 md:px-20">
-                <h2 className="flex items-center gap-2 text-xl font-bold tracking-tight text-white sm:text-2xl">
-                  My Watchlist
-                </h2>
+                <Link
+                  href={username ? `/@${username}?tab=watchlist` : "#"}
+                  className="group flex w-fit items-center gap-1.5 text-xl font-bold tracking-tight text-white sm:text-2xl"
+                >
+                  <span>My Watchlist</span>
+                  <ChevronRight className="h-5 w-5 text-zinc-400 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-white" />
+                </Link>
                 <div className="swiper-carousel-container relative w-full">
                   <Swiper
                     modules={[Mousewheel, FreeMode]}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -9,6 +9,7 @@ import { PersonalizationProvider } from "./theme-provider";
 import { ConfirmProvider } from "./ui/confirm-provider";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { NotificationProvider } from "./notification-provider";
+import { UserLibraryProvider } from "./user-library-provider";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
@@ -17,14 +18,16 @@ export function Providers({ children }: { children: ReactNode }) {
     <ConvexProvider client={convex}>
       <ConvexBetterAuthProvider client={convex} authClient={authClient as unknown as AuthClient}>
         <PersonalizationProvider>
-          <ConfirmProvider>
-            <TooltipProvider>
-              <NuqsAdapter>
-                {children}
-                <NotificationProvider />
-              </NuqsAdapter>
-            </TooltipProvider>
-          </ConfirmProvider>
+          <UserLibraryProvider>
+            <ConfirmProvider>
+              <TooltipProvider>
+                <NuqsAdapter>
+                  {children}
+                  <NotificationProvider />
+                </NuqsAdapter>
+              </TooltipProvider>
+            </ConfirmProvider>
+          </UserLibraryProvider>
         </PersonalizationProvider>
       </ConvexBetterAuthProvider>
     </ConvexProvider>

--- a/components/user-library-provider.tsx
+++ b/components/user-library-provider.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useContext, ReactNode, useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { authClient } from "@/lib/auth-client";
+
+interface UserLibraryContextType {
+  isWatchlisted: (mediaId: string | number, mediaType: string) => boolean;
+  isFavorited: (mediaId: string | number, mediaType: string) => boolean;
+  watchlistLoading: boolean;
+  favoritesLoading: boolean;
+}
+
+const UserLibraryContext = createContext<UserLibraryContextType | null>(null);
+
+export function UserLibraryProvider({ children }: { children: ReactNode }) {
+  const session = authClient.useSession();
+  const isLoggedIn = !!session.data?.user;
+
+  const watchlist = useQuery(
+    api.watchlist.getWatchlist,
+    isLoggedIn ? {} : "skip"
+  );
+
+  const favorites = useQuery(
+    api.favorites.getFavorites,
+    isLoggedIn ? {} : "skip"
+  );
+
+  const watchlistedKeysSet = useMemo(() => {
+    if (!watchlist) return new Set<string>();
+    return new Set(watchlist.map((item) => `${item.mediaType}-${item.mediaId}`));
+  }, [watchlist]);
+
+  const favoritedKeysSet = useMemo(() => {
+    if (!favorites) return new Set<string>();
+    return new Set(favorites.map((item) => `${item.mediaType}-${item.mediaId}`));
+  }, [favorites]);
+
+  const isWatchlisted = (mediaId: string | number, mediaType: string) => {
+    const type = mediaType || "movie";
+    return watchlistedKeysSet.has(`${type}-${mediaId}`);
+  };
+
+  const isFavorited = (mediaId: string | number, mediaType: string) => {
+    const type = mediaType || "movie";
+    return favoritedKeysSet.has(`${type}-${mediaId}`);
+  };
+
+  return (
+    <UserLibraryContext.Provider
+      value={{
+        isWatchlisted,
+        isFavorited,
+        watchlistLoading: isLoggedIn && watchlist === undefined,
+        favoritesLoading: isLoggedIn && favorites === undefined,
+      }}
+    >
+      {children}
+    </UserLibraryContext.Provider>
+  );
+}
+
+export function useUserLibrary() {
+  const context = useContext(UserLibraryContext);
+  if (!context) {
+    throw new Error("useUserLibrary must be used within a UserLibraryProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
- Create `UserLibraryProvider` to bulk-fetch user watchlist & favorites
- Update `Card` and `HeroSlide` components to use global cache lookups instead of duplicate per-card queries
- Reduce backend websocket query overhead on page load from O(N) to O(1)
- Link the "My Watchlist" heading on the home page to the user's public watchlist page