### PR TITLE
feat(notifications): add badge support to push notifications

### DIFF
--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -209,6 +209,7 @@ export const createGroupChat = mutation({
         body: `invited you to join the group ${cleanGroupName}.`,
         url: `/chat?id=${chatId}`,
         icon: creatorProfile?.image || "/favicon/android-chrome-192x192.png",
+        badge: "/favicon/favicon-32x32.png",
       });
     }
 
@@ -327,6 +328,7 @@ export const inviteToGroupChat = mutation({
             body: `invited you to join the group ${chat.name || "Chat"}.`,
             url: `/chat?id=${args.chatId}`,
             icon: inviterProfile?.image || "/favicon/android-chrome-192x192.png",
+            badge: "/favicon/favicon-32x32.png",
           });
         }
       }
@@ -591,6 +593,7 @@ export const sendMessage = mutation({
             body: pushBody,
             url: `/chat?id=${args.chatId}`,
             icon: senderProfile?.image || "/favicon/android-chrome-192x192.png",
+            badge: "/favicon/favicon-32x32.png",
             chatId: args.chatId,
             notificationType: "chat_message",
           });

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -210,6 +210,7 @@ export const addComment = mutation({
           body: "replied to your comment.",
           url: `/${args.mediaType}/${args.mediaId}`,
           icon: currentUser.image || "/favicon/android-chrome-192x192.png",
+          badge: "/favicon/favicon-32x32.png",
         });
       }
     }
@@ -250,6 +251,7 @@ export const addComment = mutation({
           body: "mentioned you in a comment.",
           url: `/${args.mediaType}/${args.mediaId}`,
           icon: currentUser.image || "/favicon/android-chrome-192x192.png",
+          badge: "/favicon/favicon-32x32.png",
         });
       }
     }

--- a/convex/pushActions.ts
+++ b/convex/pushActions.ts
@@ -13,6 +13,7 @@ export const sendPushNotification = internalAction({
     body: v.string(),
     url: v.optional(v.string()),
     icon: v.optional(v.string()),
+    badge: v.optional(v.string()),
     chatId: v.optional(v.string()),
     notificationType: v.optional(v.string()),
   },
@@ -43,6 +44,7 @@ export const sendPushNotification = internalAction({
       body: args.body,
       url: args.url || "/chat",
       icon: args.icon || "/favicon/android-chrome-192x192.png",
+      badge: args.badge || "/favicon/favicon-32x32.png",
       chatId: args.chatId,
       notificationType: args.notificationType,
     });

--- a/convex/social.ts
+++ b/convex/social.ts
@@ -283,6 +283,7 @@ export const sendFriendRequest = mutation({
       body: "sent you a friend request.",
       url: `/user/${senderProfile?.username || ""}`,
       icon: senderProfile?.image || "/favicon/android-chrome-192x192.png",
+      badge: "/favicon/favicon-32x32.png",
     });
   },
 });
@@ -348,6 +349,7 @@ export const acceptFriendRequest = mutation({
       body: "accepted your friend request.",
       url: `/user/${acceptorProfile?.username || ""}`,
       icon: acceptorProfile?.image || "/favicon/android-chrome-192x192.png",
+      badge: "/favicon/favicon-32x32.png",
     });
   },
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,11 +6,13 @@ self.addEventListener('push', function (event) {
     const data = event.data.json();
     const title = data.title || 'New Message';
 
-    const absoluteIcon = data.icon 
+    const absoluteIcon = data.icon
       ? (data.icon.startsWith('http') ? data.icon : `${self.location.origin}${data.icon}`)
       : `${self.location.origin}/favicon/android-chrome-192x192.png`;
-    
-    const absoluteBadge = `${self.location.origin}/favicon/favicon-32x32.png`;
+
+    const absoluteBadge = data.badge
+      ? (data.badge.startsWith('http') ? data.badge : `${self.location.origin}${data.badge}`)
+      : `${self.location.origin}/favicon/favicon-32x32.png`;
 
     const options = {
       body: data.body || 'You received a new message.',


### PR DESCRIPTION
- Added badge field to sendPushNotification action and payload
- Updated service worker to support dynamic badge resolution with fallback
- Preserved user profile image avatars for social, chat, and comment notifications